### PR TITLE
Add coverage comparison script

### DIFF
--- a/scripts/compare-coverage.mjs
+++ b/scripts/compare-coverage.mjs
@@ -1,0 +1,59 @@
+/**
+ * compare-coverage.mjs
+ *
+ * Compares Vitest coverage summary files for each app and package
+ * captured at two points, and fails if coverage has regressed.
+ *
+ * Intended for use in CI to prevent pull requests from decreasing test coverage.
+ *
+ * Arguments:
+ *   node compare-coverage.mjs <pr-dir> <baseline-dir>
+ *
+ * Exit codes:
+ *   0  coverage is unchanged or improved
+ *   1  coverage regressed in at least on project (or general script error)
+ */
+
+import fs from "node:fs";
+
+const prDir = process.argv[2];
+const baseDir = process.argv[3];
+
+const projects = fs.readdirSync(prDir).filter((file) => file.endsWith(".json"));
+
+let failed = false;
+
+for (const file of projects) {
+  const prPath = `${prDir}/${file}`;
+  const basePath = `${baseDir}/${file}`;
+
+  if (!fs.existsSync(basePath)) {
+    console.log(`⚠️ ${file.replace(".json", "")}: no baseline found, skipping`);
+    continue;
+  }
+
+  const pr = JSON.parse(fs.readFileSync(prPath));
+  const base = JSON.parse(fs.readFileSync(basePath));
+
+  const prLines = pr.total.lines.pct;
+  const baseLines = base.total.lines.pct;
+
+  const delta = (prLines - baseLines).toFixed(2);
+  const name = file.replace(".json", "");
+
+  console.log(`\nProject: ${name}`);
+  console.log(`Base: ${baseLines}%`);
+  console.log(`PR:   ${prLines}%`);
+  console.log(`Δ:    ${delta}%`);
+
+  if (prLines < baseLines) {
+    console.log("❌ Regression detected");
+    failed = true;
+  } else {
+    console.log("✅ OK");
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}


### PR DESCRIPTION
A script that takes two dirs containing coverage summaries for each app and package, measured at two points (i.e. PR vs main) and fails if regression for any project is detected.

This script needs to be merged before a PR is created with a workflow action referencing it, as that PR itself will trigger the job and fail if the script is not found.

Fixes #26 