### PR TITLE
i15-1: Disable plan buttons when a plan is running

### DIFF
--- a/apps/i15-1/src/components/RunPlanButton.tsx
+++ b/apps/i15-1/src/components/RunPlanButton.tsx
@@ -1,7 +1,11 @@
 import { Button } from "@mui/material";
 import { useState } from "react";
 
-import { useSetActiveTask, useSubmitTask } from "@atlas/blueapi-query";
+import {
+  useGetWorkerState,
+  useSetActiveTask,
+  useSubmitTask,
+} from "@atlas/blueapi-query";
 import type { TaskRequest } from "@atlas/blueapi";
 import { useUserAuth } from "../context/userAuth/useUserAuth";
 
@@ -41,8 +45,11 @@ const RunPlanButton = ({
   };
 
   const isButtonDisabled = () => {
+    const workerState = useGetWorkerState();
     const disable =
-      user.person == null || user.person == undefined ? true : false;
+      user.person == null ||
+      user.person == undefined ||
+      workerState.data !== "IDLE";
     return disable;
   };
 

--- a/apps/i15-1/src/mocks/handlers.ts
+++ b/apps/i15-1/src/mocks/handlers.ts
@@ -1,9 +1,11 @@
 import { http, HttpResponse } from "msw";
 
 const fakeTaskId = "7304e8e0-81c6-4978-9a9d-9046ab79ce3c";
+let workerStatus = { status: "IDLE", duration: 0 };
 
 export const handlers = [
   http.put("/api/worker/task", () => {
+    workerStatus.status = "RUNNING";
     return HttpResponse.json({
       task_id: fakeTaskId,
     });
@@ -21,5 +23,13 @@ export const handlers = [
 
   http.get("/oauth2/userinfo", () => {
     return HttpResponse.json({ preferredUsername: "abc123456" });
+  }),
+
+  http.get("/api/worker/state", () => {
+    if (workerStatus.duration >= 10) {
+      workerStatus.status = "IDLE";
+      workerStatus.duration = 0;
+    } else workerStatus.duration++;
+    return HttpResponse.json(workerStatus.status);
   }),
 ];


### PR DESCRIPTION
`RunPlanButton`s query the `workerState` and are disabled unless it returns `IDLE`. I've tried to make this conflict as little as possible with #29

Changes the MSW mocks so that a PUT to `/api/worker/task` also causes the next 10 GETs to `/api/worker/state` to return `RUNNING` instead of `IDLE`. Not sure if this is something to keep in long-term (especially if tests get added) but it demonstrates the effect of this PR nicely