### PR TITLE
Fixes and improvements to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /workspaces
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    vim  less \
+    vim \
+    less \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm and turbo globally

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
 # Base stage with Node.js and pnpm
-FROM node:20-bullseye AS base
+FROM node:22-bullseye AS base
 WORKDIR /workspaces
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    vim \
+    vim  less \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm and turbo globally

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,13 +8,12 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "ms-vscode.vscode-typescript-next",
         "esbenp.prettier-vscode",
         "ms-vscode.vscode-json",
         "redhat.vscode-yaml"
       ],
       "settings": {
-        "typescript.preferences.preferTypeOnlyAutoImports": true,
+        "ts.preferences.preferTypeOnlyAutoImports": true,
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.codeActionsOnSave": {


### PR DESCRIPTION
1) The most important fix is to use node 22 for the dev container. The  previous image was causing an error when we try to install pnpm@latest. This is the node version we are already using to create app images.
2) Install less for e.g. git pagination
3) Remove unnecessary extension