### PR TITLE
Update supergraph schema for instrument sessions 0.4.2

### DIFF
--- a/apps/i15-1/src/graphql/supergraph.graphql
+++ b/apps/i15-1/src/graphql/supergraph.graphql
@@ -58,10 +58,6 @@ type Mutation {
     visit: VisitInput!
     parameters: JSON!
   ): Workflow!
-  instrumentSession(
-    proposalNumber: Int!
-    instrumentSessionNumber: Int!
-  ): InstrumentSessionMutations
   createOrValidateSamples(
     input: CreateOrValidateSampleInput!
   ): CreateSamplesResponse!
@@ -72,6 +68,13 @@ type Mutation {
     input: CreateExperimentDefinitionInput!
   ): ExperimentDefinition
   experimentDefinition(id: UUID!): ExperimentDefinitionMutations
+  createInstrumentSession(
+    input: CreateInstrumentSessionInput!
+  ): InstrumentSession!
+  instrumentSession(
+    proposalNumber: Int!
+    instrumentSessionNumber: Int!
+  ): InstrumentSessionMutations
 }
 
 """
@@ -126,53 +129,13 @@ type Query {
     limit: Int
     filter: WorkflowTemplatesFilter
   ): WorkflowTemplateConnection!
+  jsonSchema(url: String!): JSONSchema
+  jsonSchemas(type: String = null, instrument: String = null): [JSONSchema!]!
 
   """
-  Get a proposal by its number
+  Get a sample by its id
   """
-  proposal(proposalNumber: Int!): Proposal
-
-  """
-  Get a list of proposals
-  """
-  proposals(
-    proposalCategory: String = null
-    first: Int = null
-    last: Int = null
-    after: String = null
-    before: String = null
-  ): ProposalConnection!
-
-  """
-  Get a instrument session
-  """
-  instrumentSession(
-    proposalNumber: Int!
-    instrumentSessionNumber: Int!
-  ): InstrumentSession
-
-  """
-  Get a instrument session
-  """
-  instrumentSessions(
-    proposalNumber: Int = null
-    proposalCategory: String = null
-  ): [InstrumentSession!]
-
-  """
-  Get an instrument
-  """
-  instrument(instrumentName: String!): Instrument
-
-  """
-  Get a list of instruments
-  """
-  instruments(scienceGroup: String = null): [Instrument!]!
-
-  """
-  Get an account
-  """
-  account(username: String!): Account
+  sample(sampleId: UUID!): Sample
 
   """
   Get a list of samples associated with a given instrument session
@@ -210,11 +173,73 @@ type Query {
   ): ExperimentConnection
 
   """
-  Get a sample by its id
+  Get a proposal by its number
   """
-  sample(sampleId: UUID!): Sample
-  jsonSchema(url: String!): JSONSchema
-  jsonSchemas(type: String = null, instrument: String = null): [JSONSchema!]!
+  proposal(proposalNumber: Int!): Proposal
+
+  """
+  Get a list of proposals
+  """
+  proposals(
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+    sortBy: [ProposalSortInput!] = null
+    filterBy: ProposalFilterInput = null
+  ): ProposalConnection!
+
+  """
+  Get a proposal by its reference string e.g. 'MX12345'. The lookup is case-insensitive.
+  """
+  proposalByReference(reference: String!): Proposal
+
+  """
+  Get a instrument session
+  """
+  instrumentSession(
+    proposalNumber: Int!
+    instrumentSessionNumber: Int!
+  ): InstrumentSession
+
+  """
+  Get an instrument session by its reference string e.g. 'MX12345-1'. The lookup is case-insensitive.
+  """
+  instrumentSessionByReference(reference: String!): InstrumentSession
+
+  """
+  Get a list of instrument sessions
+  """
+  instrumentSessions(
+    proposalNumber: Int = null
+    proposalCategory: String = null
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+    sortBy: [InstrumentSessionSortInput!] = null
+    filterBy: InstrumentSessionFilterInput = null
+  ): InstrumentSessionConnection!
+
+  """
+  Get an instrument by name
+  """
+  instrumentByName(name: String!): Instrument
+
+  """
+  Get an instrument by key
+  """
+  instrumentByKey(key: String!): Instrument
+
+  """
+  Get a list of instruments
+  """
+  instruments(scienceGroup: String = null): [Instrument!]!
+
+  """
+  Get an account
+  """
+  account(username: String!): Account
 }
 
 """
@@ -715,140 +740,44 @@ input WorkflowTemplatesFilter {
   scienceGroup: [ScienceGroup!]
 }
 
-type Account {
-  accountId: Int!
-  username: String!
-  emailAddress: String
-  title: String
-  givenName: String
-  familyName: String
-  type: AccountType!
-  state: AccountState!
-  proposalRoles: [ProposalAccount!]!
-  instrumentSessionRoles: [InstrumentSessionRole!]!
-}
+"""
+A JSON schema
+"""
+type JSONSchema {
+  """
+  The identifier of the schema
+  """
+  id: String!
 
-enum AccountState {
-  enabled
-  disabled
-}
+  """
+  A URL from which the schema can be accessed
+  """
+  url: String!
 
-enum AccountType {
-  user
-  staff
-  functional
-}
-
-type Instrument {
-  name: String!
-  scienceGroup: String
-  description: String
-  proposals: [Proposal!]!
-  instrumentSessions: [InstrumentSession!]!
-}
-
-type InstrumentSession {
-  instrumentSessionId: Int!
-  instrumentSessionNumber: Int!
-  startTime: DateTime
-  endTime: DateTime
+  """
+  The type of object the shema describes (if known)
+  """
   type: String
-  state: String
-  riskRating: String
-  proposal: Proposal
-  instrument: Instrument!
-  roles: [InstrumentSessionRole!]!
 
   """
-  Samples associated with a given instrument session
+  The title of the schema
   """
-  samples(
-    first: Int!
-    filter: SampleFilterInput! = {
-      schemaUrl: null
-      createdTime: null
-      updatedTime: null
-      name: null
-      data: null
-    }
-    before: String = null
-    after: String = null
-    last: Int = null
-    orderBy: SampleOrder! = { name: null, createdTime: null, updatedTime: null }
-  ): SampleConnection!
-
-  """
-  Experiment Definitions
-  """
-  experimentDefinitions(
-    first: Int = null
-    last: Int = null
-    after: String = null
-    before: String = null
-  ): ExperimentDefinitionConnection!
-
-  """
-  Experiments associated with this session
-  """
-  experiments(
-    first: Int = null
-    last: Int = null
-    after: String = null
-    before: String = null
-  ): ExperimentConnection!
-}
-
-type InstrumentSessionMutations {
-  instrumentSessionNumber: Int!
-  proposalNumber: Int!
-
-  """
-  Create or validate samples associated with this instrument session
-  """
-  createOrValidateSamples(
-    input: CreateOrValidateSampleInputBase!
-  ): CreateSamplesResponse!
-  experiments: [Experiment!]!
-}
-
-type InstrumentSessionRole {
-  instrumentSession: InstrumentSession!
-  account: Account!
-  role: String!
-  onSite: Boolean!
-}
-
-type Proposal {
-  proposalNumber: Int!
-  proposalCategory: String
   title: String
-  summary: String
-  state: ProposalState!
-  instrumentSessions: [InstrumentSession!]!
-  instruments: [Instrument!]!
-  roles: [ProposalAccount!]!
-}
 
-type ProposalAccount {
-  proposal: Proposal!
-  account: Account!
-  role: String!
-}
+  """
+  The version of the schema
+  """
+  version: String
 
-type ProposalConnection {
-  edges: [ProposalEdge!]!
-  pageInfo: PageInfo!
-}
+  """
+  The instrument the schema was created for
+  """
+  instrument: String
 
-type ProposalEdge {
-  cursor: String!
-  node: Proposal!
-}
-
-enum ProposalState {
-  Open
-  Closed
-  Cancelled
+  """
+  The description og the schema
+  """
+  description: String
 }
 
 input AddSampleEventInput {
@@ -958,28 +887,89 @@ type ErrorDetails {
   message: String!
 }
 
-type InstrumentSessionConnection {
-  edges: [InstrumentSessionEdge!]!
-  pageInfo: PageInfo!
+type InstrumentSession {
+  instrumentSessionNumber: Int!
+  proposal: Proposal
+
+  """
+  Samples associated with a given instrument session
+  """
+  samples(
+    first: Int!
+    filter: SampleFilterInput! = {
+      schemaUrl: null
+      createdTime: null
+      updatedTime: null
+      name: null
+      data: null
+    }
+    before: String = null
+    after: String = null
+    last: Int = null
+    orderBy: SampleOrder! = { name: null, createdTime: null, updatedTime: null }
+  ): SampleConnection!
+
+  """
+  Experiment Definitions
+  """
+  experimentDefinitions(
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+  ): ExperimentDefinitionConnection!
+
+  """
+  Experiments associated with this session
+  """
+  experiments(
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+  ): ExperimentConnection!
+  instrumentSessionId: Int!
+    @deprecated(
+      reason: "instrument_session_id is deprecated and will be removed in a future version."
+    )
+  startTime: DateTime
+  endTime: DateTime
+  type: String
+  state: String
+  riskRating: String
+
+  """
+  A human-readable reference for this session in the form '<PROPOSALCATEGORY><PROPOSALNUMBER>-<SESSIONNUMBER>' e.g. 'MX12345-1'.
+  """
+  instrumentSessionReference: String
+  instrument: Instrument!
+  roles: [InstrumentSessionRole!]!
 }
 
-type InstrumentSessionEdge {
-  cursor: String!
-  node: InstrumentSession!
-}
-
+"""
+Values required to uniquely identify an instrument session
+"""
 input InstrumentSessionInput {
   proposalNumber: Int!
   instrumentSessionNumber: Int!
 }
 
-"""
-Currently receiving an error when generating types: input JSONOperator @oneOf
-"""
+type InstrumentSessionMutations {
+  instrumentSessionNumber: Int!
+  proposalNumber: Int!
+
+  """
+  Create or validate samples associated with this instrument session
+  """
+  createOrValidateSamples(
+    input: CreateOrValidateSampleInputBase!
+  ): CreateSamplesResponse!
+}
+
 input JSONOperator @oneOf {
-  stringOperator: StringOperatorInput
-  datetimeOperator: DatetimeOperatorInput
-  numericOperator: NumericOperatorInput
+  stringOperator: StringOperatorInput = null
+  datetimeOperator: DatetimeOperatorInput = null
+  numericOperator: NumericOperatorInput = null
 }
 
 input JSONOperatorInput {
@@ -1004,6 +994,22 @@ input NumericOperatorInput {
   Will filter to items where the numeric field is less than the provided value
   """
   lt: Float = null
+}
+
+type Proposal {
+  proposalNumber: Int!
+  proposalCategory: String
+  title: String
+  summary: String
+  state: ProposalState!
+
+  """
+  A human-readable reference for this proposal in the form '<PROPOSALCATEGORY><PROPOSALNUMBER>' e.g. 'MX12345'.
+  """
+  proposalReference: String
+  instrumentSessions: [InstrumentSession!]!
+  instruments: [Instrument!]!
+  roles: [ProposalAccount!]!
 }
 
 type Sample {
@@ -1052,8 +1058,9 @@ type Sample {
   """
   The instrument sessions that this sample is associated with
   """
-  instrumentSessions: InstrumentSessionConnection!
+  instrumentSessions: [InstrumentSession!]!
   images: [SampleImage!]!
+  experiments: [Experiment!]!
 }
 
 type SampleConnection {
@@ -1136,6 +1143,7 @@ input SampleInLegacy {
 
 type SampleMutations {
   sampleId: UUID!
+  updateSample(input: UpdateSampleInput!): UpdateSampleResponse!
   linkInstrumentSessionToSample(
     proposalNumber: Int!
     instrumentSessionNumber: Int!
@@ -1205,6 +1213,43 @@ input StringOperatorInput {
 }
 
 scalar UUID
+
+input UpdateSampleInput {
+  """
+  Name of the sample
+  """
+  name: String
+
+  """
+  Data of the sample
+  """
+  data: JSON
+
+  """
+  URL of the JSON schema the samples' `data` should be validated against
+  """
+  dataSchemaUrl: String
+}
+
+"""
+Return type when creating or validating samples
+"""
+type UpdateSampleResponse {
+  """
+  Whether the operation has succeeded without validation errors
+  """
+  success: Boolean!
+
+  """
+  Sample that has been updated
+  """
+  sample: Sample
+
+  """
+  Errors that occurred during sample validation
+  """
+  errors: [SampleValidationError!]!
+}
 
 """
 Represents NULL values
@@ -1298,42 +1343,184 @@ input ExperimentInput {
   sampleId: UUID!
 }
 
-"""
-A JSON schema
-"""
-type JSONSchema {
-  """
-  The identifier of the schema
-  """
-  id: String!
-
-  """
-  A URL from which the schema can be accessed
-  """
-  url: String!
-
-  """
-  The type of object the shema describes (if known)
-  """
-  type: String
-
-  """
-  The title of the schema
-  """
+type Account {
+  accountId: Int!
+    @deprecated(
+      reason: "account_id is deprecated and will be removed in a future version."
+    )
+  username: String!
+  emailAddress: String
   title: String
+  givenName: String
+  familyName: String
+  type: AccountType!
+  state: AccountState!
+  proposalRoles: [ProposalAccount!]!
+  instrumentSessionRoles: [InstrumentSessionRole!]!
+}
+
+enum AccountState {
+  enabled
+  disabled
+}
+
+enum AccountType {
+  user
+  staff
+  functional
+}
+
+input CreateInstrumentSessionInput {
+  """
+  Number of the proposal the session is for
+  """
+  proposalNumber: Int!
 
   """
-  The version of the schema
+  Name of the instrument the session is for
   """
-  version: String
+  instrumentName: String!
 
   """
-  The instrument the schema was created for
+  Instrument Session information that isn't needed by the Session Service but should be passed through the UAS
   """
-  instrument: String
+  sessionInfo: String!
+}
 
-  """
-  The description og the schema
-  """
+input DateTimeFilterInput {
+  eq: DateTime = null
+  neq: DateTime = null
+  gt: DateTime = null
+  lt: DateTime = null
+  gte: DateTime = null
+  lte: DateTime = null
+}
+
+type Instrument {
+  name: String!
+  key: String!
+  scienceGroup: String
   description: String
+  proposals: [Proposal!]!
+  instrumentSessions: [InstrumentSession!]!
+}
+
+type InstrumentSessionConnection {
+  edges: [InstrumentSessionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type InstrumentSessionEdge {
+  cursor: String!
+  node: InstrumentSession!
+}
+
+input InstrumentSessionFilterInput {
+  instrumentSessionNumber: IntFilterInput = null
+  startTime: DateTimeFilterInput = null
+  endTime: DateTimeFilterInput = null
+  type: StringFilterInput = null
+  state: InstrumentSessionStateFilterInput = null
+  riskRating: StringFilterInput = null
+  proposalNumber: IntFilterInput = null
+}
+
+type InstrumentSessionRole {
+  instrumentSession: InstrumentSession!
+  account: Account!
+  role: String!
+  onSite: Boolean!
+}
+
+enum InstrumentSessionSortField {
+  instrumentSessionNumber
+  startTime
+  endTime
+  type
+  state
+  riskRating
+  proposalNumber
+}
+
+input InstrumentSessionSortInput {
+  field: InstrumentSessionSortField!
+  orderBy: SortOrder!
+}
+
+enum InstrumentSessionState {
+  CANCELLED
+  COMPLETED
+  FUTURE
+  IN_PROGRESS
+}
+
+input InstrumentSessionStateFilterInput {
+  eq: InstrumentSessionState = null
+  neq: InstrumentSessionState = null
+}
+
+input IntFilterInput {
+  eq: Int = null
+  neq: Int = null
+  gt: Int = null
+  lt: Int = null
+  gte: Int = null
+  lte: Int = null
+}
+
+type ProposalAccount {
+  proposal: Proposal!
+  account: Account!
+  role: String!
+}
+
+type ProposalConnection {
+  edges: [ProposalEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ProposalEdge {
+  cursor: String!
+  node: Proposal!
+}
+
+input ProposalFilterInput {
+  proposalNumber: IntFilterInput = null
+  proposalCategory: StringFilterInput = null
+  title: StringFilterInput = null
+  state: ProposalStateFilterInput = null
+}
+
+enum ProposalSortField {
+  proposalNumber
+}
+
+input ProposalSortInput {
+  field: ProposalSortField!
+  orderBy: SortOrder!
+}
+
+enum ProposalState {
+  OPEN
+  CLOSED
+  CANCELLED
+}
+
+input ProposalStateFilterInput {
+  eq: ProposalState = null
+  neq: ProposalState = null
+}
+
+enum SortOrder {
+  ASC
+  DESC
+}
+
+input StringFilterInput {
+  eq: String = null
+  neq: String = null
+  contains: String = null
+  notContains: String = null
+  startsWith: String = null
+  endsWith: String = null
 }

--- a/apps/i15-1/src/graphql/supergraph.graphql
+++ b/apps/i15-1/src/graphql/supergraph.graphql
@@ -967,9 +967,9 @@ type InstrumentSessionMutations {
 }
 
 input JSONOperator @oneOf {
-  stringOperator: StringOperatorInput = null
-  datetimeOperator: DatetimeOperatorInput = null
-  numericOperator: NumericOperatorInput = null
+  stringOperator: StringOperatorInput
+  datetimeOperator: DatetimeOperatorInput
+  numericOperator: NumericOperatorInput
 }
 
 input JSONOperatorInput {

--- a/apps/visr/helm/values.yaml
+++ b/apps/visr/helm/values.yaml
@@ -32,7 +32,7 @@ ui-base:
 
     - id: supergraph
       path: /api/graphql
-      rewriteTarget: /
+      rewriteTarget: /graphql
       target:
         external:
           uri: https://graph-nightly.diamond.ac.uk

--- a/apps/visr/src/RelayEnvironment.ts
+++ b/apps/visr/src/RelayEnvironment.ts
@@ -6,10 +6,11 @@ import {
   type FetchFunction,
 } from "relay-runtime";
 
-const HTTP_ENDPOINT = "/api/workflows";
+const HTTP_ENDPOINT = "/api/graphql";
 const fetchFn: FetchFunction = async (request, variables) => {
   const resp = await fetch(HTTP_ENDPOINT, {
     method: "POST",
+    credentials: "include",
     headers: {
       Accept:
         "application/graphql-response+json; charset=utf-8, application/json; charset=utf-8",

--- a/apps/visr/src/components/InstrumentSessionSelection/InstrumentSession.tsx
+++ b/apps/visr/src/components/InstrumentSessionSelection/InstrumentSession.tsx
@@ -1,4 +1,3 @@
-import { visitToText, type Visit } from "@diamondlightsource/sci-react-ui";
 import { useLazyLoadQuery } from "react-relay/hooks";
 import { graphql } from "relay-runtime";
 import type { InstrumentSessionQuery as InstrumentSessionQueryType } from "./__generated__/InstrumentSessionQuery.graphql";

--- a/apps/visr/src/components/InstrumentSessionSelection/InstrumentSession.tsx
+++ b/apps/visr/src/components/InstrumentSessionSelection/InstrumentSession.tsx
@@ -5,13 +5,10 @@ import type { InstrumentSessionQuery as InstrumentSessionQueryType } from "./__g
 
 const instrumentSessionQuery = graphql`
   query InstrumentSessionQuery($instrumentName: String!) {
-    instrument(instrumentName: $instrumentName) {
+    instrumentByName(name: $instrumentName) {
       instrumentSessions {
-        instrumentSessionNumber
-        proposal {
-          proposalCategory
-          proposalNumber
-        }
+        instrumentSessionReference
+        state
       }
     }
   }
@@ -23,22 +20,18 @@ function GetInstrumentSessions() {
     { instrumentName: "ViSR" },
   );
 
-  const sessionListLen = data.instrument?.instrumentSessions.length ?? 1;
+  const sessionListLen = data.instrumentByName?.instrumentSessions.length ?? 1;
   const sessionsList = [];
 
   for (let i = 0; i < sessionListLen; i++) {
-    const visit: Visit = {
-      proposalCode:
-        data.instrument?.instrumentSessions[
-          i
-        ].proposal?.proposalCategory?.toLowerCase() ?? "cm",
-      proposalNumber:
-        data.instrument?.instrumentSessions[i].proposal?.proposalNumber ??
-        12345,
-      number:
-        data.instrument?.instrumentSessions[i].instrumentSessionNumber ?? 1,
-    };
-    sessionsList.push(visitToText(visit));
+    if (
+      data.instrumentByName?.instrumentSessions[i].state === "In Progress" ||
+      data.instrumentByName?.instrumentSessions[i].state === "Future"
+    ) {
+      sessionsList.push(
+        data.instrumentByName?.instrumentSessions[i].instrumentSessionReference,
+      );
+    }
   }
   return sessionsList;
 }

--- a/apps/visr/src/components/InstrumentSessionSelection/InstrumentSession.tsx
+++ b/apps/visr/src/components/InstrumentSessionSelection/InstrumentSession.tsx
@@ -2,6 +2,8 @@ import { useLazyLoadQuery } from "react-relay/hooks";
 import { graphql } from "relay-runtime";
 import type { InstrumentSessionQuery as InstrumentSessionQueryType } from "./__generated__/InstrumentSessionQuery.graphql";
 
+// TODO: Filter query client side
+// https://github.com/DiamondLightSource/atlas/issues/81
 const instrumentSessionQuery = graphql`
   query InstrumentSessionQuery($instrumentName: String!) {
     instrumentByName(name: $instrumentName) {
@@ -28,7 +30,9 @@ function GetInstrumentSessions() {
       data.instrumentByName?.instrumentSessions[i].state === "Future"
     ) {
       sessionsList.push(
-        data.instrumentByName?.instrumentSessions[i].instrumentSessionReference,
+        data.instrumentByName?.instrumentSessions[
+          i
+        ].instrumentSessionReference?.toLowerCase(),
       );
     }
   }

--- a/apps/visr/src/components/InstrumentSessionSelection/InstrumentSessionView.tsx
+++ b/apps/visr/src/components/InstrumentSessionSelection/InstrumentSessionView.tsx
@@ -10,7 +10,11 @@ import {
   MenuItem,
 } from "@mui/material";
 
-function InstrumentSessionView({ sessionsList }: { sessionsList: string[] }) {
+function InstrumentSessionView({
+  sessionsList,
+}: {
+  sessionsList: (string | null | undefined)[];
+}) {
   const { instrumentSession, setInstrumentSession } = useInstrumentSession();
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);

--- a/apps/visr/src/components/InstrumentSessionSelection/__generated__/InstrumentSessionQuery.graphql.ts
+++ b/apps/visr/src/components/InstrumentSessionSelection/__generated__/InstrumentSessionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bd1bc2c804b6142383c22bcdbb18504a>>
+ * @generated SignedSource<<9f36acc75fb37c686d8aef477c812c01>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,13 +13,10 @@ export type InstrumentSessionQuery$variables = {
   instrumentName: string;
 };
 export type InstrumentSessionQuery$data = {
-  readonly instrument: {
+  readonly instrumentByName: {
     readonly instrumentSessions: ReadonlyArray<{
-      readonly instrumentSessionNumber: number;
-      readonly proposal: {
-        readonly proposalCategory: string | null | undefined;
-        readonly proposalNumber: number;
-      } | null | undefined;
+      readonly instrumentSessionReference: string | null | undefined;
+      readonly state: string | null | undefined;
     }>;
   } | null | undefined;
 };
@@ -42,13 +39,13 @@ v1 = [
     "args": [
       {
         "kind": "Variable",
-        "name": "instrumentName",
+        "name": "name",
         "variableName": "instrumentName"
       }
     ],
     "concreteType": "Instrument",
     "kind": "LinkedField",
-    "name": "instrument",
+    "name": "instrumentByName",
     "plural": false,
     "selections": [
       {
@@ -63,32 +60,14 @@ v1 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "instrumentSessionNumber",
+            "name": "instrumentSessionReference",
             "storageKey": null
           },
           {
             "alias": null,
             "args": null,
-            "concreteType": "Proposal",
-            "kind": "LinkedField",
-            "name": "proposal",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "proposalCategory",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "proposalNumber",
-                "storageKey": null
-              }
-            ],
+            "kind": "ScalarField",
+            "name": "state",
             "storageKey": null
           }
         ],
@@ -116,16 +95,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "625bde94466c698bcacfb6d41e195cbe",
+    "cacheID": "a04aa356857de97c58e11e861e1b53df",
     "id": null,
     "metadata": {},
     "name": "InstrumentSessionQuery",
     "operationKind": "query",
-    "text": "query InstrumentSessionQuery(\n  $instrumentName: String!\n) {\n  instrument(instrumentName: $instrumentName) {\n    instrumentSessions {\n      instrumentSessionNumber\n      proposal {\n        proposalCategory\n        proposalNumber\n      }\n    }\n  }\n}\n"
+    "text": "query InstrumentSessionQuery(\n  $instrumentName: String!\n) {\n  instrumentByName(name: $instrumentName) {\n    instrumentSessions {\n      instrumentSessionReference\n      state\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "3cb865e4a1f45b6db5b70c2cb201f4e7";
+(node as any).hash = "72ef04fa18d968be31c314c0aa6a7011";
 
 export default node;

--- a/apps/visr/src/graphql/__generated__/submitWorkflowTemplateMutation.graphql.ts
+++ b/apps/visr/src/graphql/__generated__/submitWorkflowTemplateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4f6547654b801b006d483c984e5808e1>>
+ * @generated SignedSource<<1bf0edfd66484b0fb05d16638676a62b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -47,40 +47,28 @@ v2 = {
 },
 v3 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "name",
-        "variableName": "templateName"
-      },
-      {
-        "kind": "Variable",
-        "name": "parameters",
-        "variableName": "parameters"
-      },
-      {
-        "kind": "Variable",
-        "name": "visit",
-        "variableName": "visit"
-      }
-    ],
-    "concreteType": "Workflow",
-    "kind": "LinkedField",
-    "name": "submitWorkflowTemplate",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "name",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "name",
+    "variableName": "templateName"
+  },
+  {
+    "kind": "Variable",
+    "name": "parameters",
+    "variableName": "parameters"
+  },
+  {
+    "kind": "Variable",
+    "name": "visit",
+    "variableName": "visit"
   }
-];
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -91,7 +79,20 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "submitWorkflowTemplateMutation",
-    "selections": (v3/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "Workflow",
+        "kind": "LinkedField",
+        "name": "submitWorkflowTemplate",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -104,15 +105,35 @@ return {
     ],
     "kind": "Operation",
     "name": "submitWorkflowTemplateMutation",
-    "selections": (v3/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "Workflow",
+        "kind": "LinkedField",
+        "name": "submitWorkflowTemplate",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "7d09d16bd3f1a6868e61ed6912292072",
+    "cacheID": "4c13758cbc0d34e6d9a014c9f36e641a",
     "id": null,
     "metadata": {},
     "name": "submitWorkflowTemplateMutation",
     "operationKind": "mutation",
-    "text": "mutation submitWorkflowTemplateMutation(\n  $templateName: String!\n  $visit: VisitInput!\n  $parameters: JSON!\n) {\n  submitWorkflowTemplate(name: $templateName, visit: $visit, parameters: $parameters) {\n    name\n  }\n}\n"
+    "text": "mutation submitWorkflowTemplateMutation(\n  $templateName: String!\n  $visit: VisitInput!\n  $parameters: JSON!\n) {\n  submitWorkflowTemplate(name: $templateName, visit: $visit, parameters: $parameters) {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/apps/visr/src/graphql/__generated__/workflowsQuery.graphql.ts
+++ b/apps/visr/src/graphql/__generated__/workflowsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b8dd94a5c9d130674f71ad9c16e3cc8a>>
+ * @generated SignedSource<<c3bb986a7e30fdfbeca998c39fb560a0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -73,95 +73,72 @@ v3 = {
 },
 v4 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "cursor",
-        "variableName": "cursor"
-      },
-      {
-        "kind": "Variable",
-        "name": "filter",
-        "variableName": "filter"
-      },
-      {
-        "kind": "Variable",
-        "name": "limit",
-        "variableName": "limit"
-      },
-      {
-        "kind": "Variable",
-        "name": "visit",
-        "variableName": "visit"
-      }
-    ],
-    "concreteType": "WorkflowConnection",
-    "kind": "LinkedField",
-    "name": "workflows",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Workflow",
-        "kind": "LinkedField",
-        "name": "nodes",
-        "plural": true,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "PageInfo",
-        "kind": "LinkedField",
-        "name": "pageInfo",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "endCursor",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "hasNextPage",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "hasPreviousPage",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "startCursor",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "cursor",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "limit",
+    "variableName": "limit"
+  },
+  {
+    "kind": "Variable",
+    "name": "visit",
+    "variableName": "visit"
   }
-];
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasPreviousPage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "startCursor",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -173,7 +150,32 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "workflowsQuery",
-    "selections": (v4/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": "WorkflowConnection",
+        "kind": "LinkedField",
+        "name": "workflows",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Workflow",
+            "kind": "LinkedField",
+            "name": "nodes",
+            "plural": true,
+            "selections": [
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v6/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -187,15 +189,47 @@ return {
     ],
     "kind": "Operation",
     "name": "workflowsQuery",
-    "selections": (v4/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": "WorkflowConnection",
+        "kind": "LinkedField",
+        "name": "workflows",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Workflow",
+            "kind": "LinkedField",
+            "name": "nodes",
+            "plural": true,
+            "selections": [
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v6/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "6e6da56e134de097d20cafd8abe7e0aa",
+    "cacheID": "b4890d18a10a8ed21fcc2dcbf6886c96",
     "id": null,
     "metadata": {},
     "name": "workflowsQuery",
     "operationKind": "query",
-    "text": "query workflowsQuery(\n  $visit: VisitInput!\n  $cursor: String\n  $limit: Int!\n  $filter: WorkflowFilter\n) {\n  workflows(visit: $visit, cursor: $cursor, limit: $limit, filter: $filter) {\n    nodes {\n      name\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
+    "text": "query workflowsQuery(\n  $visit: VisitInput!\n  $cursor: String\n  $limit: Int!\n  $filter: WorkflowFilter\n) {\n  workflows(visit: $visit, cursor: $cursor, limit: $limit, filter: $filter) {\n    nodes {\n      name\n      id\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n"
   }
 };
 })();

--- a/apps/visr/src/mocks/handlers.ts
+++ b/apps/visr/src/mocks/handlers.ts
@@ -3,6 +3,7 @@ import workflowsResponse from "./workflows-response.json";
 import plansResponse from "./plans-response.json";
 import { mapData } from "./mock_data";
 import type { ScanEventMessage } from "../hooks/scanEvents";
+import instrumentSessionResponse from "./instrumentSessions-response.json";
 
 const fakeTaskId = "7304e8e0-81c6-4978-9a9d-9046ab79ce3c";
 
@@ -11,6 +12,13 @@ export const handlers = [
   graphql.query("TemplateViewQuery", async () => {
     return HttpResponse.json({
       data: workflowsResponse.data,
+    });
+  }),
+
+  // Instrument session query handler
+  graphql.query("InstrumentSessionQuery", async () => {
+    return HttpResponse.json({
+      data: instrumentSessionResponse.data,
     });
   }),
 

--- a/apps/visr/src/mocks/instrumentSessions-response.json
+++ b/apps/visr/src/mocks/instrumentSessions-response.json
@@ -1,70 +1,21 @@
 {
   "data": {
-    "instrument": {
+    "instrumentByName": {
       "instrumentSessions": [
-        {
-          "instrumentSessionNumber": 1,
-          "proposal": {
-            "proposalCategory": "CM",
-            "proposalNumber": 39125
-          }
-        },
-        {
-          "instrumentSessionNumber": 2,
-          "proposal": {
-            "proposalCategory": "CM",
-            "proposalNumber": 39125
-          }
-        },
-        {
-          "instrumentSessionNumber": 3,
-          "proposal": {
-            "proposalCategory": "CM",
-            "proposalNumber": 39125
-          }
-        },
-        {
-          "instrumentSessionNumber": 1,
-          "proposal": {
-            "proposalCategory": "CM",
-            "proposalNumber": 40661
-          }
-        },
-        {
-          "instrumentSessionNumber": 2,
-          "proposal": {
-            "proposalCategory": "CM",
-            "proposalNumber": 40661
-          }
-        },
-        {
-          "instrumentSessionNumber": 3,
-          "proposal": {
-            "proposalCategory": "CM",
-            "proposalNumber": 40661
-          }
-        },
-        {
-          "instrumentSessionNumber": 4,
-          "proposal": {
-            "proposalCategory": "CM",
-            "proposalNumber": 40661
-          }
-        },
-        {
-          "instrumentSessionNumber": 5,
-          "proposal": {
-            "proposalCategory": "CM",
-            "proposalNumber": 40661
-          }
-        },
-        {
-          "instrumentSessionNumber": 6,
-          "proposal": {
-            "proposalCategory": "CM",
-            "proposalNumber": 40661
-          }
-        }
+        { "instrumentSessionReference": "CM39125-1", "state": "Completed" },
+        { "instrumentSessionReference": "CM39125-2", "state": "Completed" },
+        { "instrumentSessionReference": "CM39125-3", "state": "Completed" },
+        { "instrumentSessionReference": "CM40661-1", "state": "Completed" },
+        { "instrumentSessionReference": "CM40661-2", "state": "Completed" },
+        { "instrumentSessionReference": "CM40661-3", "state": "Completed" },
+        { "instrumentSessionReference": "CM40661-4", "state": "Completed" },
+        { "instrumentSessionReference": "CM40661-5", "state": "Completed" },
+        { "instrumentSessionReference": "CM40661-6", "state": "Completed" },
+        { "instrumentSessionReference": "CM44191-1", "state": "Completed" },
+        { "instrumentSessionReference": "CM44191-2", "state": "Completed" },
+        { "instrumentSessionReference": "CM44191-3", "state": "In Progress" },
+        { "instrumentSessionReference": "CM44191-4", "state": "Future" },
+        { "instrumentSessionReference": "CM44191-5", "state": "Future" }
       ]
     }
   }

--- a/apps/visr/src/routes/Dashboard.tsx
+++ b/apps/visr/src/routes/Dashboard.tsx
@@ -4,7 +4,7 @@ import FeedIcon from "@mui/icons-material/Feed";
 import AddchartIcon from "@mui/icons-material/Addchart";
 import { Link } from "react-router-dom";
 import InstrumentSessionView from "../components/InstrumentSessionSelection/InstrumentSessionView";
-// import GetInstrumentSessions from "../components/InstrumentSessionSelection/InstrumentSession";
+import GetInstrumentSessions from "../components/InstrumentSessionSelection/InstrumentSession";
 
 function Dashboard() {
   return (
@@ -52,16 +52,7 @@ function Dashboard() {
               <Typography sx={{ mt: "4px" }}>Workflows</Typography>
             </Button>
           </Stack>
-          {/* <InstrumentSessionView sessionsList={GetInstrumentSessions()} /> */}
-          <InstrumentSessionView
-            sessionsList={[
-              "cm44191-1",
-              "cm44191-2",
-              "cm44191-3",
-              "cm44191-4",
-              "cm44191-5",
-            ]}
-          />
+          <InstrumentSessionView sessionsList={GetInstrumentSessions()} />
         </Stack>
       </Container>
     </>

--- a/apps/visr/supergraph.graphql
+++ b/apps/visr/supergraph.graphql
@@ -3,10 +3,12 @@ type Artifact {
   The file name of the artifact
   """
   name: String!
+
   """
   The download URL for the artifact
   """
   url: Url!
+
   """
   The MIME type of the artifact data
   """
@@ -23,7 +25,7 @@ The input/output is a string in RFC3339 format.
 scalar DateTime
 
 """
-A scalar that can represent any JSON value.
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).
 """
 scalar JSON
 
@@ -40,6 +42,7 @@ type LogEntry {
   The log line content
   """
   content: String!
+
   """
   The name of the pod producing the log
   """
@@ -55,28 +58,188 @@ type Mutation {
     visit: VisitInput!
     parameters: JSON!
   ): Workflow!
+  createOrValidateSamples(
+    input: CreateOrValidateSampleInput!
+  ): CreateSamplesResponse!
+  createSamples(input: CreateSampleInput!): [Sample!]!
+    @deprecated(reason: "Will be replaced by createOrValidateSamples")
+  sample(sampleId: UUID!): SampleMutations
+  createExperimentDefinition(
+    input: CreateExperimentDefinitionInput!
+  ): ExperimentDefinition
+  experimentDefinition(id: UUID!): ExperimentDefinitionMutations
+  createInstrumentSession(
+    input: CreateInstrumentSessionInput!
+  ): InstrumentSession!
+  instrumentSession(
+    proposalNumber: Int!
+    instrumentSessionNumber: Int!
+  ): InstrumentSessionMutations
 }
+
+"""
+Represents Relay Node types
+"""
+union NodeValue = Workflow
 
 """
 Information about pagination in a connection
 """
-type PageInfo @shareable {
+type PageInfo {
   """
   When paginating backwards, are there more items?
   """
   hasPreviousPage: Boolean!
+
   """
   When paginating forwards, are there more items?
   """
   hasNextPage: Boolean!
+
   """
   When paginating backwards, the cursor to continue.
   """
   startCursor: String
+
   """
   When paginating forwards, the cursor to continue.
   """
   endCursor: String
+}
+
+"""
+The root query of the service
+"""
+type Query {
+  node(id: ID!): NodeValue
+
+  """
+  Get a single [`Workflow`] by proposal, visit, and name
+  """
+  workflow(visit: VisitInput!, name: String!): Workflow!
+  workflows(
+    visit: VisitInput!
+    cursor: String
+    limit: Int
+    filter: WorkflowFilter
+  ): WorkflowConnection!
+  workflowTemplate(name: String!): WorkflowTemplate!
+  workflowTemplates(
+    cursor: String
+    limit: Int
+    filter: WorkflowTemplatesFilter
+  ): WorkflowTemplateConnection!
+  jsonSchema(url: String!): JSONSchema
+  jsonSchemas(type: String = null, instrument: String = null): [JSONSchema!]!
+
+  """
+  Get a sample by its id
+  """
+  sample(sampleId: UUID!): Sample
+
+  """
+  Get a list of samples associated with a given instrument session
+  """
+  samples(
+    first: Int!
+    instrumentSessions: [InstrumentSessionInput!] = null
+    filter: SampleFilterInput! = {
+      schemaUrl: null
+      createdTime: null
+      updatedTime: null
+      name: null
+      data: null
+    }
+    before: String = null
+    after: String = null
+    last: Int = null
+    orderBy: SampleOrder! = { name: null, createdTime: null, updatedTime: null }
+  ): SampleConnection!
+  experimentDefinition(id: UUID!): ExperimentDefinition
+  experimentDefinitions(
+    instrumentSessions: [InstrumentSessionInput!]!
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+  ): ExperimentDefinitionConnection
+  experiment(id: UUID!): Experiment
+  experiments(
+    instrumentSessions: [InstrumentSessionInput!]!
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+  ): ExperimentConnection
+
+  """
+  Get a proposal by its number
+  """
+  proposal(proposalNumber: Int!): Proposal
+
+  """
+  Get a list of proposals
+  """
+  proposals(
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+    sortBy: [ProposalSortInput!] = null
+    filterBy: ProposalFilterInput = null
+  ): ProposalConnection!
+
+  """
+  Get a proposal by its reference string e.g. 'MX12345'. The lookup is case-insensitive.
+  """
+  proposalByReference(reference: String!): Proposal
+
+  """
+  Get a instrument session
+  """
+  instrumentSession(
+    proposalNumber: Int!
+    instrumentSessionNumber: Int!
+  ): InstrumentSession
+
+  """
+  Get an instrument session by its reference string e.g. 'MX12345-1'. The lookup is case-insensitive.
+  """
+  instrumentSessionByReference(reference: String!): InstrumentSession
+
+  """
+  Get a list of instrument sessions
+  """
+  instrumentSessions(
+    proposalNumber: Int = null
+    proposalCategory: String = null
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+    sortBy: [InstrumentSessionSortInput!] = null
+    filterBy: InstrumentSessionFilterInput = null
+  ): InstrumentSessionConnection!
+
+  """
+  Get an instrument by name
+  """
+  instrumentByName(name: String!): Instrument
+
+  """
+  Get an instrument by key
+  """
+  instrumentByKey(key: String!): Instrument
+
+  """
+  Get a list of instruments
+  """
+  instruments(scienceGroup: String = null): [Instrument!]!
+
+  """
+  Get an account
+  """
+  account(username: String!): Account
 }
 
 """
@@ -87,34 +250,42 @@ enum ScienceGroup {
   Macromolecular Crystallography
   """
   MX
+
   """
   Workflows Examples
   """
   EXAMPLES
+
   """
   Magnetic Materials
   """
   MAGNETIC_MATERIALS
+
   """
   Soft Condensed Matter
   """
   CONDENSED_MATTER
+
   """
   Imaging and Microscopy
   """
   IMAGING
+
   """
   Biological Cryo-Imaging
   """
   BIO_CRYO_IMAGING
+
   """
   Structures and Surfaces
   """
   SURFACES
+
   """
   Crystallography
   """
   CRYSTALLOGRAPHY
+
   """
   Spectroscopy
   """
@@ -129,6 +300,7 @@ type Subscription {
   Processing to subscribe to logs for a single pod of a workflow
   """
   logs(visit: VisitInput!, workflowName: String!, taskId: String!): LogEntry!
+
   """
   Processing to subscribe to data for all workflows in a session
   """
@@ -140,38 +312,47 @@ type Task {
   Unique name of the task
   """
   id: String!
+
   """
   Display name of the task
   """
   name: String!
+
   """
   Current status of a task
   """
   status: TaskStatus!
+
   """
   Parent of a task
   """
   depends: [String!]!
+
   """
   Children of a task
   """
   dependencies: [String!]!
+
   """
   Artifacts produced by a task
   """
   artifacts: [Artifact!]!
+
   """
   Node type - Pod, DAG, etc
   """
   stepType: String!
+
   """
   Start time for a task on a workflow
   """
   startTime: DateTime
+
   """
   End time for a task on a workflow
   """
   endTime: DateTime
+
   """
   A human readable message indicating details about why this step is in this condition
   """
@@ -191,6 +372,26 @@ enum TaskStatus {
 scalar Template
 
 """
+Information about where the template is stored
+"""
+type TemplateSource {
+  """
+  The URL of the GitHub repository
+  """
+  repositoryUrl: String!
+
+  """
+  The path to the template within the repository
+  """
+  path: String!
+
+  """
+  The current tracked branch of the repository
+  """
+  targetRevision: String!
+}
+
+"""
 URL is a String implementing the [URL Standard](http://url.spec.whatwg.org/)
 """
 scalar Url
@@ -203,10 +404,12 @@ type Visit {
   Project Proposal Code
   """
   proposalCode: String!
+
   """
   Project Proposal Number
   """
   proposalNumber: Int!
+
   """
   Session visit Number
   """
@@ -221,10 +424,12 @@ input VisitInput {
   Project Proposal Code
   """
   proposalCode: String!
+
   """
   Project Proposal Number
   """
   proposalNumber: Int!
+
   """
   Session visit Number
   """
@@ -233,40 +438,52 @@ input VisitInput {
 
 type Workflow {
   """
+  The unique ID derived from the visit and name
+  """
+  id: ID!
+
+  """
   The name given to the workflow, unique within a given visit
   """
   name: String!
+
   """
   The visit the Workflow was run against
   """
   visit: Visit!
+
   """
   The current status of the workflow
   """
   status: WorkflowStatus
+
   """
   The top-level workflow parameters
   """
   parameters: JSONObject
+
   """
   The name of the template used to run the workflow
   """
   templateRef: String
+
   """
   The workflow creator
   """
   creator: WorkflowCreator!
 }
 
-type WorkflowConnection @shareable {
+type WorkflowConnection {
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+
   """
   A list of edges.
   """
   edges: [WorkflowEdge!]!
+
   """
   A list of nodes.
   """
@@ -287,11 +504,12 @@ type WorkflowCreator {
 """
 An edge in a connection.
 """
-type WorkflowEdge @shareable {
+type WorkflowEdge {
   """
   The item at the end of the edge
   """
   node: Workflow!
+
   """
   A cursor for use in pagination
   """
@@ -306,14 +524,17 @@ type WorkflowErroredStatus {
   Time at which this workflow started
   """
   startTime: DateTime!
+
   """
   Time at which this workflow completed
   """
   endTime: DateTime!
+
   """
   A human readable message indicating details about why the workflow is in this condition
   """
   message: String
+
   """
   Tasks created by the workflow
   """
@@ -328,14 +549,17 @@ type WorkflowFailedStatus {
   Time at which this workflow started
   """
   startTime: DateTime!
+
   """
   Time at which this workflow completed
   """
   endTime: DateTime!
+
   """
   A human readable message indicating details about why the workflow is in this condition
   """
   message: String
+
   """
   Tasks created by the workflow
   """
@@ -350,10 +574,12 @@ input WorkflowFilter {
   The status field for a workflow
   """
   workflowStatusFilter: WorkflowStatusFilter
+
   """
   The fedid of the user who created the workflow
   """
   creator: Creator
+
   """
   The name of the workflow template
   """
@@ -372,10 +598,12 @@ type WorkflowRunningStatus {
   Time at which this workflow started
   """
   startTime: DateTime!
+
   """
   A human readable message indicating details about why the workflow is in this condition
   """
   message: String
+
   """
   Tasks created by the workflow
   """
@@ -411,14 +639,17 @@ type WorkflowSucceededStatus {
   Time at which this workflow started
   """
   startTime: DateTime!
+
   """
   Time at which this workflow completed
   """
   endTime: DateTime!
+
   """
   A human readable message indicating details about why the workflow is in this condition
   """
   message: String
+
   """
   Tasks created by the workflow
   """
@@ -430,41 +661,54 @@ type WorkflowTemplate {
   The name given to the workflow template, globally unique
   """
   name: String!
+
   """
   The group who maintains the workflow template
   """
   maintainer: String!
+
   """
   A human readable title for the workflow template
   """
   title: String
+
   """
   A human readable description of the workflow which is created
   """
   description: String
+
   """
   The repository storing the code associated with this template.
   """
   repository: String
+
   """
   A JSON Schema describing the arguments of a Workflow Template
   """
   arguments: JSON!
+
   """
   A JSON Forms UI Schema describing how to render the arguments of the Workflow Template
   """
   uiSchema: JSON
+
+  """
+  Information about where the template is obtained from
+  """
+  templateSource: TemplateSource
 }
 
-type WorkflowTemplateConnection @shareable {
+type WorkflowTemplateConnection {
   """
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+
   """
   A list of edges.
   """
   edges: [WorkflowTemplateEdge!]!
+
   """
   A list of nodes.
   """
@@ -474,11 +718,12 @@ type WorkflowTemplateConnection @shareable {
 """
 An edge in a connection.
 """
-type WorkflowTemplateEdge @shareable {
+type WorkflowTemplateEdge {
   """
   The item at the end of the edge
   """
   node: WorkflowTemplate!
+
   """
   A cursor for use in pagination
   """
@@ -496,20 +741,613 @@ input WorkflowTemplatesFilter {
 }
 
 """
-Directs the executor to include this field or fragment only when the `if` argument is true.
+A JSON schema
 """
-directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+type JSONSchema {
+  """
+  The identifier of the schema
+  """
+  id: String!
+
+  """
+  A URL from which the schema can be accessed
+  """
+  url: String!
+
+  """
+  The type of object the shema describes (if known)
+  """
+  type: String
+
+  """
+  The title of the schema
+  """
+  title: String
+
+  """
+  The version of the schema
+  """
+  version: String
+
+  """
+  The instrument the schema was created for
+  """
+  instrument: String
+
+  """
+  The description og the schema
+  """
+  description: String
+}
+
+input AddSampleEventInput {
+  description: String!
+}
+
+input CreateOrValidateSampleInput {
+  """
+  URL of the JSON schema the samples' `data` should be validated against
+  """
+  dataSchemaUrl: String!
+
+  """
+  Samples to be created
+  """
+  samples: [SampleIn!]!
+
+  """
+  Whether or not the provided samples should only be validated and not created
+  """
+  validateOnly: Boolean! = false
+
+  """
+  Number of the proposal the samples should be associated with
+  """
+  proposalNumber: Int!
+
+  """
+  Number of the instrument session the samples should be associated with
+  """
+  instrumentSessionNumber: Int!
+}
+
+input CreateOrValidateSampleInputBase {
+  """
+  URL of the JSON schema the samples' `data` should be validated against
+  """
+  dataSchemaUrl: String!
+
+  """
+  Samples to be created
+  """
+  samples: [SampleIn!]!
+
+  """
+  Whether or not the provided samples should only be validated and not created
+  """
+  validateOnly: Boolean! = false
+}
+
+input CreateSampleInput {
+  proposalNumber: Int!
+  instrumentSessionNumber: Int!
+  samples: [SampleInLegacy!]!
+  validateOnly: Boolean! = false
+}
+
 """
-Directs the executor to skip this field or fragment when the `if` argument is true.
+Return type when creating or validating samples
 """
-directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+type CreateSamplesResponse {
+  """
+  Whether the operation has succeeded without validation errors
+  """
+  success: Boolean!
+
+  """
+  Samples that have been created
+  """
+  samples: [Sample!]!
+
+  """
+  Errors that occurred during sample validation
+  """
+  errors: [SampleValidationError!]!
+}
+
+input DatetimeOperatorInput {
+  """
+  Will filter to items where the `DateTime` field is greater than (i.e. after) the provided value
+  """
+  gt: DateTime = null
+
+  """
+  Will filter to items where the `DateTime` field is less than (i.e. before) the provided value
+  """
+  lt: DateTime = null
+}
+
 """
-Provides a scalar specification URL for specifying the behavior of custom scalar types.
+The details of sample validation error
 """
-directive @specifiedBy(url: String!) on SCALAR
+type ErrorDetails {
+  """
+  The type of error that occurred
+  """
+  type: String!
+
+  """
+  Tuple of strings identifying where in the sample schema the error occurred.
+  """
+  location: [String!]!
+
+  """
+  A human readable error message.
+  """
+  message: String!
+}
+
+type InstrumentSession {
+  instrumentSessionNumber: Int!
+  proposal: Proposal
+
+  """
+  Samples associated with a given instrument session
+  """
+  samples(
+    first: Int!
+    filter: SampleFilterInput! = {
+      schemaUrl: null
+      createdTime: null
+      updatedTime: null
+      name: null
+      data: null
+    }
+    before: String = null
+    after: String = null
+    last: Int = null
+    orderBy: SampleOrder! = { name: null, createdTime: null, updatedTime: null }
+  ): SampleConnection!
+
+  """
+  Experiment Definitions
+  """
+  experimentDefinitions(
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+  ): ExperimentDefinitionConnection!
+
+  """
+  Experiments associated with this session
+  """
+  experiments(
+    first: Int = null
+    last: Int = null
+    after: String = null
+    before: String = null
+  ): ExperimentConnection!
+  instrumentSessionId: Int!
+    @deprecated(
+      reason: "instrument_session_id is deprecated and will be removed in a future version."
+    )
+  startTime: DateTime
+  endTime: DateTime
+  type: String
+  state: String
+  riskRating: String
+
+  """
+  A human-readable reference for this session in the form '<PROPOSALCATEGORY><PROPOSALNUMBER>-<SESSIONNUMBER>' e.g. 'MX12345-1'.
+  """
+  instrumentSessionReference: String
+  instrument: Instrument!
+  roles: [InstrumentSessionRole!]!
+}
+
+"""
+Values required to uniquely identify an instrument session
+"""
+input InstrumentSessionInput {
+  proposalNumber: Int!
+  instrumentSessionNumber: Int!
+}
+
+type InstrumentSessionMutations {
+  instrumentSessionNumber: Int!
+  proposalNumber: Int!
+
+  """
+  Create or validate samples associated with this instrument session
+  """
+  createOrValidateSamples(
+    input: CreateOrValidateSampleInputBase!
+  ): CreateSamplesResponse!
+}
+
+input JSONOperator @oneOf {
+  stringOperator: StringOperatorInput = null
+  datetimeOperator: DatetimeOperatorInput = null
+  numericOperator: NumericOperatorInput = null
+}
+
+input JSONOperatorInput {
+  """
+  A JSON path specifying the value to filter. Must start with '$.'
+  """
+  path: String!
+
+  """
+  The operator to apply to the JSON field
+  """
+  operator: JSONOperator!
+}
+
+input NumericOperatorInput {
+  """
+  Will filter to items where the numeric field is greater than the provided value
+  """
+  gt: Float = null
+
+  """
+  Will filter to items where the numeric field is less than the provided value
+  """
+  lt: Float = null
+}
+
+type Proposal {
+  proposalNumber: Int!
+  proposalCategory: String
+  title: String
+  summary: String
+  state: ProposalState!
+
+  """
+  A human-readable reference for this proposal in the form '<PROPOSALCATEGORY><PROPOSALNUMBER>' e.g. 'MX12345'.
+  """
+  proposalReference: String
+  instrumentSessions: [InstrumentSession!]!
+  instruments: [Instrument!]!
+  roles: [ProposalAccount!]!
+}
+
+type Sample {
+  id: UUID!
+  name: String!
+  data: JSON!
+  createdTime: DateTime!
+  updatedTime: DateTime!
+  dataSchemaUrl: String!
+
+  """
+  Samples from which this sample is derived
+  """
+  parents(
+    first: Int = null
+    before: String = null
+    after: String = null
+    last: Int = null
+  ): SampleConnection!
+
+  """
+  Samples derived from this sample
+  """
+  children(
+    first: Int = null
+    before: String = null
+    after: String = null
+    last: Int = null
+  ): SampleConnection!
+
+  """
+  Events linked to this sample
+  """
+  events(
+    first: Int = null
+    before: String = null
+    after: String = null
+    last: Int = null
+  ): SampleEventConnection!
+
+  """
+  The JSON schema that the sample's `data` conforms to
+  """
+  dataSchema: JSON!
+
+  """
+  The instrument sessions that this sample is associated with
+  """
+  instrumentSessions: [InstrumentSession!]!
+  images: [SampleImage!]!
+  experiments: [Experiment!]!
+}
+
+type SampleConnection {
+  edges: [SampleEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SampleEdge {
+  cursor: String!
+  node: Sample!
+}
+
+type SampleEvent {
+  id: UUID!
+  timestamp: DateTime!
+  description: String!
+}
+
+type SampleEventConnection {
+  edges: [SampleEventEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SampleEventEdge {
+  cursor: String!
+  node: SampleEvent!
+}
+
+input SampleFilterInput {
+  """
+  Filter on the `schemaUrl` field of `Sample`
+  """
+  schemaUrl: StringOperatorInput = null
+
+  """
+  Filter on the `createdTime` field of `Sample`
+  """
+  createdTime: DatetimeOperatorInput = null
+
+  """
+  Filter on the `createdTime` field of `Sample`
+  """
+  updatedTime: DatetimeOperatorInput = null
+
+  """
+  Filter on the `name` field of `Sample`
+  """
+  name: StringOperatorInput = null
+
+  """
+  Filter on the `data` field of `Sample`
+  """
+  data: [JSONOperatorInput!] = null
+}
+
+type SampleImage {
+  url: String!
+  filename: String!
+}
+
+input SampleIn {
+  """
+  Name of the sample
+  """
+  name: String!
+
+  """
+  Data of the sample
+  """
+  data: JSON!
+}
+
+input SampleInLegacy {
+  name: String!
+  data: JSON!
+  dataSchemaUrl: String!
+  parentIds: [Int!] = null
+  children: [SampleInLegacy!] = null
+}
+
+type SampleMutations {
+  sampleId: UUID!
+  updateSample(input: UpdateSampleInput!): UpdateSampleResponse!
+  linkInstrumentSessionToSample(
+    proposalNumber: Int!
+    instrumentSessionNumber: Int!
+  ): Void
+  addSampleEvent(sampleEvent: AddSampleEventInput!): SampleEvent!
+  createSampleImageUploadUrl(
+    filename: String!
+    contentType: String!
+    contentLength: Int!
+  ): String!
+}
+
+input SampleOrder {
+  name: SortingOrder = null
+  createdTime: SortingOrder = null
+  updatedTime: SortingOrder = null
+}
+
+"""
+The details of errors occurred when validating a sample
+"""
+type SampleValidationError {
+  """
+  The index of the sample in CreateSampleInput.samples for which the error occurred
+  """
+  index: Int!
+
+  """
+  Errors that occurred when validating the sample
+  """
+  errors: [ErrorDetails!]!
+}
+
+enum SortingOrder {
+  ASC
+  DESC
+}
+
+"""
+Conditions used to filter results based on the value of a String field
+"""
+input StringOperatorInput {
+  """
+  Will filter to items where the `String` field is equal to the provided value
+  """
+  eq: String = null
+
+  """
+  Will filter to items where the `String` field is not equal to the provided value
+  """
+  ne: String = null
+
+  """
+  Will filter to items where the `String` field is a member of the provided value
+  """
+  in: [String!] = null
+
+  """
+  Will filter to items where the `String` field is not a member of the provided value
+  """
+  nin: [String!] = null
+
+  """
+  Will filter to items where the `String` field is contains the provided value
+  """
+  contains: String = null
+}
+
+scalar UUID
+
+input UpdateSampleInput {
+  """
+  Name of the sample
+  """
+  name: String
+
+  """
+  Data of the sample
+  """
+  data: JSON
+
+  """
+  URL of the JSON schema the samples' `data` should be validated against
+  """
+  dataSchemaUrl: String
+}
+
+"""
+Return type when creating or validating samples
+"""
+type UpdateSampleResponse {
+  """
+  Whether the operation has succeeded without validation errors
+  """
+  success: Boolean!
+
+  """
+  Sample that has been updated
+  """
+  sample: Sample
+
+  """
+  Errors that occurred during sample validation
+  """
+  errors: [SampleValidationError!]!
+}
+
+"""
+Represents NULL values
+"""
+scalar Void
+
+"""
+Values required to create an experiment definition
+"""
+input CreateExperimentDefinitionInput {
+  name: String!
+  data: JSON!
+  dataSchemaUrl: String!
+  proposalNumber: Int!
+  instrumentSessionNumber: Int!
+}
+
+"""
+Values required for the createExperiments mutation
+"""
+input CreateExperimentsInput {
+  experiments: [ExperimentInput!]!
+}
+
+type Experiment {
+  id: UUID!
+  name: String!
+  createdTime: DateTime!
+  updatedTime: DateTime!
+  experimentDefinition: ExperimentDefinition!
+
+  """
+  The sample that this experiment is associated with
+  """
+  sample: Sample!
+}
+
+type ExperimentConnection {
+  edges: [ExperimentEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ExperimentDefinition {
+  id: UUID!
+  name: String!
+  createdTime: DateTime!
+  updatedTime: DateTime!
+  data: JSON!
+  dataSchemaUrl: String!
+  proposalNumber: Int!
+  instrumentSessionNumber: Int!
+
+  """
+  The instrument session that this experiment definition is associated with
+  """
+  instrumentSession: InstrumentSession!
+
+  """
+  Experiments associated with this experiment definition
+  """
+  experiments: [Experiment!]!
+}
+
+type ExperimentDefinitionConnection {
+  edges: [ExperimentDefinitionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ExperimentDefinitionEdge {
+  cursor: String!
+  node: ExperimentDefinition!
+}
+
+"""
+Mutations for a given experiment defintion
+"""
+type ExperimentDefinitionMutations {
+  createExperiments(input: CreateExperimentsInput!): [Experiment!]!
+}
+
+type ExperimentEdge {
+  cursor: String!
+  node: Experiment!
+}
+
+"""
+Values required to create an experiment
+"""
+input ExperimentInput {
+  name: String!
+  sampleId: UUID!
+}
 
 type Account {
   accountId: Int!
+    @deprecated(
+      reason: "account_id is deprecated and will be removed in a future version."
+    )
   username: String!
   emailAddress: String
   title: String
@@ -532,30 +1370,59 @@ enum AccountType {
   functional
 }
 
-"""
-Date with time (isoformat)
-"""
-scalar DateTime
+input CreateInstrumentSessionInput {
+  """
+  Number of the proposal the session is for
+  """
+  proposalNumber: Int!
+
+  """
+  Name of the instrument the session is for
+  """
+  instrumentName: String!
+
+  """
+  Instrument Session information that isn't needed by the Session Service but should be passed through the UAS
+  """
+  sessionInfo: String!
+}
+
+input DateTimeFilterInput {
+  eq: DateTime = null
+  neq: DateTime = null
+  gt: DateTime = null
+  lt: DateTime = null
+  gte: DateTime = null
+  lte: DateTime = null
+}
 
 type Instrument {
   name: String!
+  key: String!
   scienceGroup: String
   description: String
   proposals: [Proposal!]!
   instrumentSessions: [InstrumentSession!]!
 }
 
-type InstrumentSession {
-  instrumentSessionId: Int!
-  instrumentSessionNumber: Int!
-  startTime: DateTime
-  endTime: DateTime
-  type: String
-  state: String
-  riskRating: String
-  proposal: Proposal
-  instrument: Instrument!
-  roles: [InstrumentSessionRole!]!
+type InstrumentSessionConnection {
+  edges: [InstrumentSessionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type InstrumentSessionEdge {
+  cursor: String!
+  node: InstrumentSession!
+}
+
+input InstrumentSessionFilterInput {
+  instrumentSessionNumber: IntFilterInput = null
+  startTime: DateTimeFilterInput = null
+  endTime: DateTimeFilterInput = null
+  type: StringFilterInput = null
+  state: InstrumentSessionStateFilterInput = null
+  riskRating: StringFilterInput = null
+  proposalNumber: IntFilterInput = null
 }
 
 type InstrumentSessionRole {
@@ -565,15 +1432,40 @@ type InstrumentSessionRole {
   onSite: Boolean!
 }
 
-type Proposal {
-  proposalNumber: Int!
-  proposalCategory: String
-  title: String
-  summary: String
-  state: ProposalState!
-  instrumentSessions: [InstrumentSession!]!
-  instruments: [Instrument!]!
-  roles: [ProposalAccount!]!
+enum InstrumentSessionSortField {
+  instrumentSessionNumber
+  startTime
+  endTime
+  type
+  state
+  riskRating
+  proposalNumber
+}
+
+input InstrumentSessionSortInput {
+  field: InstrumentSessionSortField!
+  orderBy: SortOrder!
+}
+
+enum InstrumentSessionState {
+  CANCELLED
+  COMPLETED
+  FUTURE
+  IN_PROGRESS
+}
+
+input InstrumentSessionStateFilterInput {
+  eq: InstrumentSessionState = null
+  neq: InstrumentSessionState = null
+}
+
+input IntFilterInput {
+  eq: Int = null
+  neq: Int = null
+  gt: Int = null
+  lt: Int = null
+  gte: Int = null
+  lte: Int = null
 }
 
 type ProposalAccount {
@@ -582,67 +1474,53 @@ type ProposalAccount {
   role: String!
 }
 
-enum ProposalState {
-  Open
-  Closed
-  Cancelled
+type ProposalConnection {
+  edges: [ProposalEdge!]!
+  pageInfo: PageInfo!
 }
 
-type Query {
-  """
-  Get a single [`Workflow`] by proposal, visit, and name
-  """
-  workflow(visit: VisitInput!, name: String!): Workflow!
-  workflows(
-    visit: VisitInput!
-    cursor: String
-    limit: Int
-    filter: WorkflowFilter
-  ): WorkflowConnection!
-  workflowTemplate(name: String!): WorkflowTemplate!
-  workflowTemplates(
-    cursor: String
-    limit: Int
-    filter: WorkflowTemplatesFilter
-  ): WorkflowTemplateConnection!
-  """
-  Get a proposal by its number
-  """
-  proposal(proposalNumber: Int!): Proposal
+type ProposalEdge {
+  cursor: String!
+  node: Proposal!
+}
 
-  """
-  Get a list of proposals
-  """
-  proposals(proposalCategory: String = null): [Proposal!]!
+input ProposalFilterInput {
+  proposalNumber: IntFilterInput = null
+  proposalCategory: StringFilterInput = null
+  title: StringFilterInput = null
+  state: ProposalStateFilterInput = null
+}
 
-  """
-  Get a instrument session
-  """
-  instrumentSession(
-    proposalNumber: Int!
-    instrumentSessionNumber: Int!
-  ): InstrumentSession
+enum ProposalSortField {
+  proposalNumber
+}
 
-  """
-  Get a instrument session
-  """
-  instrumentSessions(
-    proposalNumber: Int = null
-    proposalCategory: String = null
-  ): [InstrumentSession!]
+input ProposalSortInput {
+  field: ProposalSortField!
+  orderBy: SortOrder!
+}
 
-  """
-  Get an instrument
-  """
-  instrument(instrumentName: String!): Instrument
+enum ProposalState {
+  OPEN
+  CLOSED
+  CANCELLED
+}
 
-  """
-  Get a list of instruments
-  """
-  instruments(scienceGroup: String = null): [Instrument!]!
+input ProposalStateFilterInput {
+  eq: ProposalState = null
+  neq: ProposalState = null
+}
 
-  """
-  Get an account
-  """
-  account(username: String!): Account
+enum SortOrder {
+  ASC
+  DESC
+}
+
+input StringFilterInput {
+  eq: String = null
+  neq: String = null
+  contains: String = null
+  notContains: String = null
+  startsWith: String = null
+  endsWith: String = null
 }


### PR DESCRIPTION
Fixes #76

Updates supergraph.graphql for ViSR and i15-1.

Adds instrument sessions query back into ViSR, and updates instrument sessions query to follow new schema and use instrumentSessionReference (cm12345-1), rather than concatenating proposalCategory (cm), proposalNumber (12345), and instrumentSessionNumber (1) ourselves. Also updates upstreams for new cosmo router, relay environment, handlers, etc.

Allows i15-1 to use new queries in the future, ensures types can be auto-generated. 