### PR TITLE
i15-1: Send ULIMS experiments to queue

### DIFF
--- a/apps/i15-1/src/components/ExperimentTable/ULIMSExperimentTable.test.tsx
+++ b/apps/i15-1/src/components/ExperimentTable/ULIMSExperimentTable.test.tsx
@@ -1,21 +1,38 @@
-import { render, screen, fireEvent } from "@atlas/vitest-conf";
+import { render, screen, fireEvent, waitFor } from "@atlas/vitest-conf";
 import { describe, it, expect, vi, afterEach, type Mock } from "vitest";
 import { ExperimentList } from "./ULIMSExperimentsTable";
 import * as apollo from "@apollo/client/react";
 import { MemoryRouter } from "react-router-dom";
+import * as queueService from "../../queue/queueService";
 
 vi.mock("@apollo/client/react", async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal<typeof import("@apollo/client/react")>();
   return {
-    actual,
+    ...actual,
     useQuery: vi.fn(),
   };
 });
 
+vi.mock("../../queue/queueService", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../queue/queueService")>();
+  return {
+    ...actual,
+    useSumbitTask: vi.fn(),
+  };
+});
+
+const mockedUseSubmitTask = queueService.useSumbitTask as unknown as Mock;
 const mockedUseQuery = apollo.useQuery as unknown as Mock;
 
 afterEach(() => {
-  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  mockedUseSubmitTask.mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+  });
 });
 
 const mockExperiments = {
@@ -34,6 +51,26 @@ const mockExperiments = {
             },
             experimentDefinition: {
               name: "Def 1",
+              data: {
+                beam_energy: 20,
+                time_per_pdf: 10,
+                focused_beam_size: 5,
+              },
+            },
+          },
+        },
+        {
+          node: {
+            name: "Exp 2",
+            sample: {
+              name: "Sample B",
+              data: {
+                density: 1.2,
+                composition: "CO2",
+              },
+            },
+            experimentDefinition: {
+              name: "Def 2",
               data: {
                 beam_energy: 20,
                 time_per_pdf: 10,
@@ -126,5 +163,90 @@ describe("ExperimentList", () => {
         name: /add selected 1 to queue/i,
       }),
     ).toBeInTheDocument();
+  });
+
+  it("submits selected tasks when clicking 'Add selected ... to queue'", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+
+    mockedUseQuery.mockReturnValue({
+      data: mockExperiments,
+      loading: false,
+      error: undefined,
+    } as unknown as ReturnType<typeof apollo.useQuery>);
+
+    mockedUseSubmitTask.mockReturnValue({
+      mutateAsync,
+    });
+
+    renderComponent();
+
+    const checkbox = screen.getAllByRole("checkbox")[1];
+    fireEvent.click(checkbox);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /add selected 1 to queue/i }),
+    );
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledTimes(1);
+      expect(mutateAsync).toHaveBeenCalledWith({
+        taskPosition: 0,
+        taskParams: {
+          experimentName: "Exp 1",
+          sampleName: "Sample A",
+          density: 1.2,
+          composition: "H2O",
+          beamEnergy: 20,
+          timePerPDF: 10,
+          beamSize: 5,
+        },
+      });
+    });
+  });
+
+  it("submits all tasks when clicking 'Add all to queue'", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+
+    mockedUseQuery.mockReturnValue({
+      data: mockExperiments,
+      loading: false,
+      error: undefined,
+    } as unknown as ReturnType<typeof apollo.useQuery>);
+
+    mockedUseSubmitTask.mockReturnValue({
+      mutateAsync,
+    });
+
+    renderComponent();
+
+    fireEvent.click(screen.getByRole("button", { name: /add all to queue/i }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledTimes(2);
+      expect(mutateAsync).toHaveBeenNthCalledWith(1, {
+        taskPosition: 0,
+        taskParams: {
+          experimentName: "Exp 1",
+          sampleName: "Sample A",
+          density: 1.2,
+          composition: "H2O",
+          beamEnergy: 20,
+          timePerPDF: 10,
+          beamSize: 5,
+        },
+      });
+      expect(mutateAsync).toHaveBeenNthCalledWith(2, {
+        taskPosition: 1,
+        taskParams: {
+          experimentName: "Exp 2",
+          sampleName: "Sample B",
+          density: 1.2,
+          composition: "CO2",
+          beamEnergy: 20,
+          timePerPDF: 10,
+          beamSize: 5,
+        },
+      });
+    });
   });
 });

--- a/apps/i15-1/src/components/ExperimentTable/ULIMSExperimentsTable.tsx
+++ b/apps/i15-1/src/components/ExperimentTable/ULIMSExperimentsTable.tsx
@@ -9,7 +9,7 @@ import { columns, type ExperimentTableData } from "./columns";
 import { useLocation } from "react-router-dom";
 import { useMemo } from "react";
 import QueueIcon from "@mui/icons-material/Queue";
-
+import { useSumbitTask } from "../../queue/queueService";
 import { getSessionPlaylistQuery } from "../../graphql/getSessionPlaylistQuery";
 import { type ExperimentNode } from "../../graphql/getSessionPlaylistQueryTyped";
 import type {
@@ -51,6 +51,18 @@ const GET_EXPERIMENTS: TypedDocumentNode<
 
 export function ExperimentList() {
   const location = useLocation();
+  const { mutateAsync: submitTaskAsync } = useSumbitTask();
+
+  async function submitTasks(selected: ExperimentTableData[]) {
+    await Promise.all(
+      selected.map((exp, index) =>
+        submitTaskAsync({
+          taskPosition: index,
+          taskParams: exp,
+        }),
+      ),
+    );
+  }
 
   const { data, loading, error } = useQuery(GET_EXPERIMENTS, {
     variables: {
@@ -102,18 +114,29 @@ export function ExperimentList() {
               variant="contained"
               color="primary"
               startIcon={<QueueIcon />}
-              onClick={() => {
+              onClick={async () => {
                 const selected = table
                   .getSelectedRowModel()
                   .rows.map((row) => row.original);
-
-                console.log("Selected:", selected);
+                await submitTasks(selected);
               }}
             >
               Add selected {selectedCount} to queue
             </Button>
           ) : (
-            <Button variant="contained" startIcon={<QueueIcon />}>
+            <Button
+              variant="contained"
+              startIcon={<QueueIcon />}
+              onClick={async () => {
+                table.toggleAllRowsSelected(true);
+
+                const allRows = table
+                  .getPrePaginationRowModel()
+                  .rows.map((row) => row.original);
+
+                await submitTasks(allRows);
+              }}
+            >
               Add all to queue
             </Button>
           )}

--- a/apps/i15-1/src/main.tsx
+++ b/apps/i15-1/src/main.tsx
@@ -8,10 +8,8 @@ import { router } from "./router.tsx";
 import { createApi } from "@atlas/blueapi";
 import { AppProviders } from "./AppProviders.tsx";
 
-const QUEUE_MODE = import.meta.env.VITE_QUEUE_MODE;
-
 async function enableMocking() {
-  if (import.meta.env.DEV && QUEUE_MODE != "local") {
+  if (import.meta.env.DEV) {
     const { worker } = await import("./mocks/browser");
     return worker.start();
   }

--- a/apps/i15-1/src/mocks/handlers.ts
+++ b/apps/i15-1/src/mocks/handlers.ts
@@ -33,6 +33,30 @@ const fakeExperiments = {
               },
             },
           },
+          {
+            node: {
+              name: "Test experiment 2",
+              sample: {
+                name: "Test_sample 2",
+                data: {
+                  density: 56,
+                  capillary: "bs1.5",
+                  composition: "Stuff",
+                  packing_fraction: 0.5,
+                },
+              },
+              experimentDefinition: {
+                name: "My Experiment",
+                data: {
+                  q_max: 67,
+                  frames: 100,
+                  beam_energy: 40,
+                  time_per_pdf: 2,
+                  focused_beam_size: 3,
+                },
+              },
+            },
+          },
         ],
       },
     },

--- a/apps/i15-1/src/queue/queueService.ts
+++ b/apps/i15-1/src/queue/queueService.ts
@@ -265,12 +265,12 @@ export const submitTask = async ({
         plan_name: "run_full_collection",
         sample_id: sampleId,
         params: taskParams,
-        instrument_session: "cm123-123",
+        instrument_session: "cm44163-3",
       },
     ],
     query: {
       position: taskPosition,
-      // @ts-ignore -
+      // @ts-ignore
       validate_with_blueapi: false,
     },
   };

--- a/apps/i15-1/src/queue/queueService.ts
+++ b/apps/i15-1/src/queue/queueService.ts
@@ -270,7 +270,8 @@ export const submitTask = async ({
     ],
     query: {
       position: taskPosition,
-      // @ts-ignore
+      // @ts-expect-error - validation is still a bit in flux,
+      // see https://github.com/DiamondLightSource/daq-queuing-service/issues/42
       validate_with_blueapi: false,
     },
   };

--- a/apps/i15-1/src/queue/queueService.ts
+++ b/apps/i15-1/src/queue/queueService.ts
@@ -2,13 +2,21 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import axios, { type AxiosInstance } from "axios";
 import { useEffect, useRef } from "react";
-import type { QueueState, TaskCancelRequest } from "../../generated/queue";
+import type {
+  QueueState,
+  TaskCancelRequest,
+  AddTasksToQueueQueuePostData,
+} from "../../generated/queue";
+import { addTasksToQueueQueuePost } from "../../generated/queue";
+import { client } from "../../generated/queue/client.gen";
 import type { QueuedTasks } from "./tasks";
 
 // This should be tidied up in https://github.com/DiamondLightSource/atlas/issues/59
 const QUEUE_MODE = import.meta.env.VITE_QUEUE_MODE;
 const QUEUE_SOCKET: string =
   QUEUE_MODE === "local" ? "http://127.0.0.1:8001" : "/api/daq-queue";
+
+client.setConfig({ baseUrl: QUEUE_SOCKET });
 
 const handlers = {
   state_update: "state",
@@ -239,3 +247,46 @@ export const clearHistory = async (): Promise<number> => {
 
   return response.data;
 };
+
+export const submitTask = async ({
+  taskPosition,
+  taskParams,
+}: {
+  taskPosition: number;
+  taskParams: Record<string, unknown>;
+}) => {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const sampleId = `test_1_${timestamp}`;
+
+  const data: AddTasksToQueueQueuePostData = {
+    url: `/queue`,
+    body: [
+      {
+        plan_name: "run_full_collection",
+        sample_id: sampleId,
+        params: taskParams,
+        instrument_session: "cm123-123",
+      },
+    ],
+    query: {
+      position: taskPosition,
+      // @ts-ignore -
+      validate_with_blueapi: false,
+    },
+  };
+
+  return await addTasksToQueueQueuePost(data);
+};
+
+export function useSumbitTask() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: submitTask,
+    onSuccess: async () => {
+      await Promise.all([
+        client.invalidateQueries({ queryKey: ["queue"] }),
+        client.invalidateQueries({ queryKey: ["tasks"] }),
+      ]);
+    },
+  });
+}


### PR DESCRIPTION
Fixes #72

To test:
* Run a local queueserver (as per instructions in https://github.com/DiamondLightSource/daq-queuing-service#daq_queuing_service)
* Start the UI pointing to the local queueserver (as per instructions in https://github.com/DiamondLightSource/atlas/tree/main/apps/i15-1#running-locally)
* Select items in the `Setup` table and queue them
* Confirm these items appear in the `Queue` view

Note that running the items in the queue will immediately fail as it's trying to use a non-existent plan. https://github.com/DiamondLightSource/daq-queuing-service/issues/45 will fix this