### PR TITLE
Sanitise blueapi /plans schemas for better JSONForms rendering

### DIFF
--- a/apps/i15-1/src/mocks/plans-response.json
+++ b/apps/i15-1/src/mocks/plans-response.json
@@ -1,32 +1,100 @@
 {
   "plans": [
     {
-      "name": "hi_plan",
-      "description": "Says hi to you",
-      "schema": {
-        "properties": { "name": { "title": "Name", "type": "string" } }
-      }
-    },
-    {
       "name": "count",
-      "description": "Reads from a number of devices.\n    Wraps bluesky.plans.count(det, num, delay, md=metadata) exposing only serializable\n    parameters and metadata.",
+      "description": "Reads from a number of devices.\n\n    Wraps bluesky.plans.count(det, num, delay, md=metadata) exposing only serializable\n    parameters and metadata.\n    ",
       "schema": {
         "additionalProperties": false,
         "properties": {
           "detectors": {
             "items": {
-              "enum": [
-                "sample_stage",
-                "sample_det",
-                "oav",
-                "synchrotron",
-                "panda"
-              ],
-              "type": "bluesky.protocols.Readable"
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
             },
             "title": "Detectors",
-            "type": "array",
-            "uniqueItems": true
+            "type": "array"
           },
           "num": {
             "title": "Num",
@@ -47,6 +115,7 @@
             "title": "Delay"
           },
           "metadata": {
+            "additionalProperties": true,
             "title": "Metadata",
             "type": "object"
           }
@@ -57,79 +126,1229 @@
       }
     },
     {
+      "name": "list_grid_rscan",
+      "description": "Scan independent trajectories, relative to current positions.\n\n    The scan is defined by providing a list of points for each scan trajectory. Snakes\n    all fast axes by default (all axes but the first axis provided). Wraps\n    bluesky.plans.rel_list_grid_scan(det, *args, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "snake_axes": {
+            "title": "Snake Axes",
+            "type": "boolean"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "list_grid_rscan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_grid_scan",
+      "description": "Scan independent trajectories.\n\n    The scan is defined by providing a list of points for each scan trajectory. Snakes\n    all fast axes by default (all axes but the first axis provided). Wraps\n    bluesky.plans.list_grid_scan(det, *args, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "snake_axes": {
+            "title": "Snake Axes",
+            "type": "boolean"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "list_grid_scan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_rscan",
+      "description": "Scan concurrent trajector(y/ies), relative to current position.\n\n    The scan is defined by providing a list of points for each scan trajectory.\n    Wraps bluesky.plans.rel_list_scan(det, *args, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "list_rscan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "list_scan",
+      "description": "Scan concurrent single or multi-motor trajector(y/ies).\n\n    The scan is defined by providing a list of points for each scan trajectory.\n    Wraps bluesky.plans.list_scan(det, *args, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "list_scan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "num_grid_rscan",
+      "description": "Scan independent trajectories, relative to current positions.\n\n    The scan is defined by number of points along scan trajectories. Snakes all fast\n    axes by default (all axes but the first axis provided). Wraps\n    bluesky.plans.rel_grid_scan(det, *args, snake_axes, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "snake_axes": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "title": "Snake Axes"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "num_grid_rscan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "num_grid_scan",
+      "description": "Scan independent multi-motor trajectories.\n\n    The scan is defined by number of points along scan trajectories. Snakes all fast\n    axes by default (all axes but the first axis provided). Wraps\n    bluesky.plans.grid_scan(det, *args, snake_axes, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "snake_axes": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "title": "Snake Axes"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "num_grid_scan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "num_rscan",
+      "description": "Scan concurrent trajector(y/ies), relative to current position(s).\n\n    The scan is defined by number of points along scan trajector(y/ies). Wraps\n    bluesky.plans.rel_scan(det, *args, num, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "num": {
+            "title": "Num",
+            "type": "integer"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "num_rscan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "num_scan",
+      "description": "Scan concurrent single or multi-motor trajector(y/ies).\n\n    The scan is defined by number of points along scan trajector(y/ies). Wraps\n    bluesky.plans.scan(det, *args, num, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "num": {
+            "title": "Num",
+            "type": "integer"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params", "num"],
+        "title": "num_scan",
+        "type": "object"
+      }
+    },
+    {
       "name": "spec_scan",
       "description": "Generic plan for reading `detectors` at every point of a ScanSpec `Spec`.\n    A `Spec` is an N-dimensional path.\n    ",
       "schema": {
         "$defs": {
-          "Circle_Reference_": {
-            "additionalProperties": false,
-            "description": "Mask contains points of axis within an xy circle of given radius.\n\n.. example_spec::\n\n    from scanspec.regions import Circle\n    from scanspec.specs import Line\n\n    grid = Line(\"y\", 1, 3, 10) * ~Line(\"x\", 0, 2, 10)\n    spec = grid & Circle(\"x\", \"y\", 1, 2, 0.9)",
-            "properties": {
-              "x_axis": {
-                "description": "The name matching the x axis of the spec",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
-                "title": "X Axis",
-                "type": "bluesky.protocols.Movable"
-              },
-              "y_axis": {
-                "description": "The name matching the y axis of the spec",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
-                "title": "Y Axis",
-                "type": "bluesky.protocols.Movable"
-              },
-              "x_middle": {
-                "description": "The central x point of the circle",
-                "title": "X Middle",
-                "type": "number"
-              },
-              "y_middle": {
-                "description": "The central y point of the circle",
-                "title": "Y Middle",
-                "type": "number"
-              },
-              "radius": {
-                "description": "Radius of the circle",
-                "exclusiveMinimum": 0,
-                "title": "Radius",
-                "type": "number"
-              },
-              "type": {
-                "const": "Circle",
-                "default": "Circle",
-                "title": "Type",
-                "type": "string"
-              }
-            },
-            "required": ["x_axis", "y_axis", "x_middle", "y_middle", "radius"],
-            "title": "Circle",
-            "type": "object"
-          },
-          "CombinationOf_Reference_": {
-            "additionalProperties": false,
-            "description": "Abstract baseclass for a combination of two regions, left and right.",
-            "properties": {
-              "left": {
-                "$ref": "#/$defs/Region",
-                "description": "The left-hand Region to combine"
-              },
-              "right": {
-                "$ref": "#/$defs/Region",
-                "description": "The right-hand Region to combine"
-              },
-              "type": {
-                "const": "CombinationOf",
-                "default": "CombinationOf",
-                "title": "Type",
-                "type": "string"
-              }
-            },
-            "required": ["left", "right"],
-            "title": "CombinationOf",
-            "type": "object"
-          },
           "Concat_Reference_": {
             "additionalProperties": false,
-            "description": "Concatenate two Specs together, running one after the other.\n\nEach Dimension of left and right must contain the same axes. Typically\nformed using `Spec.concat`.\n\n.. example_spec::\n\n    from scanspec.specs import Line\n\n    spec = Line(\"x\", 1, 3, 3).concat(Line(\"x\", 4, 5, 5))",
+            "description": "Concatenate two Specs together, running one after the other.\n\nEach Dimension of left and right must contain the same axes. Typically\nformed using `Spec.concat`.\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace\n\n    spec = Fly(Linspace(\"x\", 1, 3, 3).concat(Linspace(\"x\", 4, 5, 5)))",
             "properties": {
               "left": {
                 "$ref": "#/$defs/Spec",
@@ -162,72 +1381,121 @@
             "title": "Concat",
             "type": "object"
           },
-          "DifferenceOf_Reference_": {
+          "ConstantDuration_Reference_": {
             "additionalProperties": false,
-            "description": "A point is in DifferenceOf(a, b) if in a and not in b.\n\nTypically created with the ``-`` operator.\n\n>>> r = Range(\"x\", 0.5, 2.5) - Range(\"x\", 1.5, 3.5)\n>>> r.mask({\"x\": np.array([0, 1, 2, 3, 4])})\narray([False,  True, False, False, False])",
+            "description": "Apply a constant duration to every point in a Spec.\n\nTypically applied with the ``@`` modifier.\n\n.. example_spec::\n\n    from scanspec.specs import Linspace\n\n    spec = 0.1 @ Linspace(\"x\", 1, 2, 3)",
             "properties": {
-              "left": {
-                "$ref": "#/$defs/Region",
-                "description": "The left-hand Region to combine"
+              "constant_duration": {
+                "description": "The value at each point",
+                "title": "Constant Duration",
+                "type": "number"
               },
-              "right": {
-                "$ref": "#/$defs/Region",
-                "description": "The right-hand Region to combine"
+              "spec": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Spec"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Spec contaning the path to be followed"
               },
               "type": {
-                "const": "DifferenceOf",
-                "default": "DifferenceOf",
+                "const": "ConstantDuration",
+                "default": "ConstantDuration",
                 "title": "Type",
                 "type": "string"
               }
             },
-            "required": ["left", "right"],
-            "title": "DifferenceOf",
+            "required": ["constant_duration"],
+            "title": "ConstantDuration",
             "type": "object"
           },
           "Ellipse_Reference_": {
             "additionalProperties": false,
-            "description": "Mask contains points of axis within an xy ellipse of given radius.\n\n.. example_spec::\n\n    from scanspec.regions import Ellipse\n    from scanspec.specs import Line\n\n    grid = Line(\"y\", 3, 8, 10) * ~Line(\"x\", 1 ,8, 10)\n    spec = grid & Ellipse(\"x\", \"y\", 5, 5, 2, 3, 75)",
+            "description": "Grid of points masked to an elliptical footprint.\n\nConstructs a 2-D scan over an axis-aligned ellipse defined by\n``(x_axis, y_axis)``, centred at (``x_centre``, ``y_centre``), with\ndiameters ``x_diameter`` and ``y_diameter``. Grid spacing along each axis is\ncontrolled by ``x_step`` and ``y_step``. If ``snake`` is True, the fast\naxis will zigzag like a snake. If ``vertical`` is True, the y axis will be\nthe fast axis.\n\nStarts from one of the four extremes of the ellipse identified by the signs of\n``x_step`` and ``y_step``.\n\n.. example_spec::\n\n    from scanspec.specs import Ellipse, Fly\n\n    # An elliptical region centred at (0, 0) on axes \"x\" and \"y\",\n    # with 10x6 diameters and steps of 0.5 in both directions.\n    spec = Fly(\n        Ellipse(\n            \"x\", 0, 10, 0.5,\n            \"y\", 0, 6,\n            snake=True,\n            vertical=False,\n        )\n    )",
             "properties": {
               "x_axis": {
-                "description": "The name matching the x axis of the spec",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
+                "description": "An identifier for what to move for x",
+                "enum": [
+                  "attenuator",
+                  "base_y",
+                  "blower_z",
+                  "cobra",
+                  "cryostream",
+                  "env_x",
+                  "f2y",
+                  "fast_shutter",
+                  "hutch_shutter",
+                  "robot",
+                  "tth"
+                ],
                 "title": "X Axis",
                 "type": "bluesky.protocols.Movable"
               },
+              "x_centre": {
+                "description": "x centre of the spiral",
+                "title": "X Centre",
+                "type": "number"
+              },
+              "x_diameter": {
+                "description": "x width of the spiral",
+                "title": "X Diameter",
+                "type": "number"
+              },
+              "x_step": {
+                "description": "Spacing along x",
+                "exclusiveMinimum": 0,
+                "title": "X Step",
+                "type": "number"
+              },
               "y_axis": {
-                "description": "The name matching the y axis of the spec",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
+                "description": "An identifier for what to move for y",
+                "enum": [
+                  "attenuator",
+                  "base_y",
+                  "blower_z",
+                  "cobra",
+                  "cryostream",
+                  "env_x",
+                  "f2y",
+                  "fast_shutter",
+                  "hutch_shutter",
+                  "robot",
+                  "tth"
+                ],
                 "title": "Y Axis",
                 "type": "bluesky.protocols.Movable"
               },
-              "x_middle": {
-                "description": "The central x point of the ellipse",
-                "title": "X Middle",
+              "y_centre": {
+                "description": "y centre of the spiral",
+                "title": "Y Centre",
                 "type": "number"
               },
-              "y_middle": {
-                "description": "The central y point of the ellipse",
-                "title": "Y Middle",
+              "y_diameter": {
+                "description": "y width of the spiral (defaults to x_diameter)",
+                "title": "Y Diameter",
                 "type": "number"
               },
-              "x_radius": {
-                "description": "The radius along the x axis of the ellipse",
+              "y_step": {
+                "description": "Spacing along y (defaults to x_step)",
                 "exclusiveMinimum": 0,
-                "title": "X Radius",
+                "title": "Y Step",
                 "type": "number"
               },
-              "y_radius": {
-                "description": "The radius along the y axis of the ellipse",
-                "exclusiveMinimum": 0,
-                "title": "Y Radius",
-                "type": "number"
+              "snake": {
+                "default": false,
+                "description": "If True, path zigzag like a snake (defaults to False)",
+                "title": "Snake",
+                "type": "boolean"
               },
-              "angle": {
-                "default": 0,
-                "description": "The angle of the ellipse (degrees)",
-                "title": "Angle",
-                "type": "number"
+              "vertical": {
+                "default": false,
+                "description": "If True, y axis is the fast axis (defaults to False)",
+                "title": "Vertical",
+                "type": "boolean"
               },
               "type": {
                 "const": "Ellipse",
@@ -238,45 +1506,53 @@
             },
             "required": [
               "x_axis",
+              "x_centre",
+              "x_diameter",
+              "x_step",
               "y_axis",
-              "x_middle",
-              "y_middle",
-              "x_radius",
-              "y_radius"
+              "y_centre"
             ],
             "title": "Ellipse",
             "type": "object"
           },
-          "IntersectionOf_Reference_": {
+          "Fly_Reference_": {
             "additionalProperties": false,
-            "description": "A point is in IntersectionOf(a, b) if in both a and b.\n\nTypically created with the ``&`` operator.\n\n>>> r = Range(\"x\", 0.5, 2.5) & Range(\"x\", 1.5, 3.5)\n>>> r.mask({\"x\": np.array([0, 1, 2, 3, 4])})\narray([False, False,  True, False, False])",
+            "description": "Move through lower to upper bounds of the Spec rather than stopping.\n\nThis is commonly termed a \"fly scan\" rather than a \"step scan\"\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace\n\n    spec = Fly(Linspace(\"x\", 1, 2, 3))",
             "properties": {
-              "left": {
-                "$ref": "#/$defs/Region",
-                "description": "The left-hand Region to combine"
-              },
-              "right": {
-                "$ref": "#/$defs/Region",
-                "description": "The right-hand Region to combine"
+              "spec": {
+                "$ref": "#/$defs/Spec",
+                "description": "Spec contaning the path to be followed"
               },
               "type": {
-                "const": "IntersectionOf",
-                "default": "IntersectionOf",
+                "const": "Fly",
+                "default": "Fly",
                 "title": "Type",
                 "type": "string"
               }
             },
-            "required": ["left", "right"],
-            "title": "IntersectionOf",
+            "required": ["spec"],
+            "title": "Fly",
             "type": "object"
           },
-          "Line_Reference_": {
+          "Linspace_Reference_": {
             "additionalProperties": false,
-            "description": "Linearly spaced frames with start and stop as first and last midpoints.\n\n.. example_spec::\n\n    from scanspec.specs import Line\n\n    spec = Line(\"x\", 1, 2, 5)",
+            "description": "Linearly spaced frames with start and stop as first and last midpoints.\n\nThis class is intended to handle linearly spaced frames defined with a\nspecific number of frames.\n\n.. seealso::\n    `Range`: For linearly spaced frames defined with a step size.\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace\n\n    spec = Fly(Linspace(\"x\", 1, 2, 5))",
             "properties": {
               "axis": {
                 "description": "An identifier for what to move",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
+                "enum": [
+                  "attenuator",
+                  "base_y",
+                  "blower_z",
+                  "cobra",
+                  "cryostream",
+                  "env_x",
+                  "f2y",
+                  "fast_shutter",
+                  "hutch_shutter",
+                  "robot",
+                  "tth"
+                ],
                 "title": "Axis",
                 "type": "bluesky.protocols.Movable"
               },
@@ -291,84 +1567,104 @@
                 "type": "number"
               },
               "num": {
-                "description": "Number of frames to produce",
+                "default": 1,
+                "description": "Number of frames to produce (defaults to 1)",
                 "minimum": 1,
                 "title": "Num",
                 "type": "integer"
               },
               "type": {
-                "const": "Line",
-                "default": "Line",
+                "const": "Linspace",
+                "default": "Linspace",
                 "title": "Type",
                 "type": "string"
               }
             },
-            "required": ["axis", "start", "stop", "num"],
-            "title": "Line",
-            "type": "object"
-          },
-          "Mask_Reference_": {
-            "additionalProperties": false,
-            "description": "Restrict Spec to only midpoints that fall inside the given Region.\n\nTypically created with the ``&`` operator. It also pushes down the\n``& | ^ -`` operators to its `Region` to avoid the need for brackets on\ncombinations of Regions.\n\nIf a Region spans multiple Frames objects, they will be squashed together.\n\n.. example_spec::\n\n    from scanspec.regions import Circle\n    from scanspec.specs import Line\n\n    spec = Line(\"y\", 1, 3, 3) * Line(\"x\", 3, 5, 5) & Circle(\"x\", \"y\", 4, 2, 1.2)\n\nSee Also: `why-squash-can-change-path`",
-            "properties": {
-              "spec": {
-                "$ref": "#/$defs/Spec",
-                "description": "The Spec containing the source midpoints"
-              },
-              "region": {
-                "$ref": "#/$defs/Region",
-                "description": "The Region that midpoints will be inside"
-              },
-              "check_path_changes": {
-                "default": true,
-                "description": "If True path through scan will not be modified by squash",
-                "title": "Check Path Changes",
-                "type": "boolean"
-              },
-              "type": {
-                "const": "Mask",
-                "default": "Mask",
-                "title": "Type",
-                "type": "string"
-              }
-            },
-            "required": ["spec", "region"],
-            "title": "Mask",
+            "required": ["axis", "start", "stop"],
+            "title": "Linspace",
             "type": "object"
           },
           "Polygon_Reference_": {
             "additionalProperties": false,
-            "description": "Mask contains points of axis within a rotated xy polygon.\n\n.. example_spec::\n\n    from scanspec.regions import Polygon\n    from scanspec.specs import Line\n\n    grid = Line(\"y\", 3, 8, 10) * ~Line(\"x\", 1 ,8, 10)\n    spec = grid & Polygon(\"x\", \"y\", [1.0, 6.0, 8.0, 2.0], [4.0, 10.0, 6.0, 1.0])",
+            "description": "Grid of points masked to a polygonal footprint.\n\nConstructs a 2-D scan over an axis-aligned polygon defined by an ordered\nlist of vertices \"(x, y)\" given in ``vertices``. The polygon may be convex\nor concave, and the interior is determined using an even-odd ray-casting\nrule. Grid spacing along each axis is controlled by ``x_step`` and ``y_step``,\nIf ``snake`` is True, the fast axis will zigzag like a snake. If ``vertical`` is\nTrue, the y axis will be the fast axis.\n\n.. example_spec::\n\n    from scanspec.specs import Polygon, Fly\n\n    # A triangular region on axes \"x\" and \"y\", stepped by 0.2 units\n    # in both directions.\n    spec = Fly(\n        Polygon(\n            x_axis=\"x\",\n            y_axis=\"y\",\n            vertices=[(0, 0), (5, 0), (2.5, 4)],\n            x_step=0.2,\n            y_step=0.2,\n            snake=True,\n            vertical=False,\n        )\n    )",
             "properties": {
               "x_axis": {
-                "description": "The name matching the x axis of the spec",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
+                "description": "An identifier for what to move for x",
+                "enum": [
+                  "attenuator",
+                  "base_y",
+                  "blower_z",
+                  "cobra",
+                  "cryostream",
+                  "env_x",
+                  "f2y",
+                  "fast_shutter",
+                  "hutch_shutter",
+                  "robot",
+                  "tth"
+                ],
                 "title": "X Axis",
                 "type": "bluesky.protocols.Movable"
               },
               "y_axis": {
-                "description": "The name matching the y axis of the spec",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
+                "description": "An identifier for what to move for y",
+                "enum": [
+                  "attenuator",
+                  "base_y",
+                  "blower_z",
+                  "cobra",
+                  "cryostream",
+                  "env_x",
+                  "f2y",
+                  "fast_shutter",
+                  "hutch_shutter",
+                  "robot",
+                  "tth"
+                ],
                 "title": "Y Axis",
                 "type": "bluesky.protocols.Movable"
               },
-              "x_verts": {
-                "description": "The Nx1 x coordinates of the polygons vertices",
+              "vertices": {
+                "description": "List of (x, y) vertices defining the polygon",
                 "items": {
-                  "type": "number"
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "prefixItems": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ],
+                  "type": "array"
                 },
-                "minItems": 3,
-                "title": "X Verts",
+                "title": "Vertices",
                 "type": "array"
               },
-              "y_verts": {
-                "description": "The Nx1 y coordinates of the polygons vertices",
-                "items": {
-                  "type": "number"
-                },
-                "minItems": 3,
-                "title": "Y Verts",
-                "type": "array"
+              "x_step": {
+                "description": "Spacing along x",
+                "exclusiveMinimum": 0,
+                "title": "X Step",
+                "type": "number"
+              },
+              "y_step": {
+                "description": "Spacing along y (defaults to x_step)",
+                "exclusiveMinimum": 0,
+                "title": "Y Step",
+                "type": "number"
+              },
+              "snake": {
+                "default": false,
+                "description": "If True, path zigzag like a snake (defaults to False)",
+                "title": "Snake",
+                "type": "boolean"
+              },
+              "vertical": {
+                "default": false,
+                "description": "If True, y axis is the fast axis (defaults to False)",
+                "title": "Vertical",
+                "type": "boolean"
               },
               "type": {
                 "const": "Polygon",
@@ -377,21 +1673,43 @@
                 "type": "string"
               }
             },
-            "required": ["x_axis", "y_axis", "x_verts", "y_verts"],
+            "required": ["x_axis", "y_axis", "vertices", "x_step"],
             "title": "Polygon",
             "type": "object"
           },
           "Product_Reference_": {
             "additionalProperties": false,
-            "description": "Outer product of two Specs, nesting inner within outer.\n\nThis means that inner will run in its entirety at each point in outer.\n\n.. example_spec::\n\n    from scanspec.specs import Line\n\n    spec = Line(\"y\", 1, 2, 3) * Line(\"x\", 3, 4, 12)",
+            "description": "Outer product of two Specs, nesting inner within outer.\n\nThis means that inner will run in its entirety at each point in outer.\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace\n\n    spec = Fly(Linspace(\"y\", 1, 2, 3) * Linspace(\"x\", 3, 4, 12))\n\nAn inner integer can be used to repeat the same point many times.\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace\n\n    spec = Fly(Linspace(\"y\", 1, 2, 3) * 2)\n\nAn outer integer can be used to repeat the same scan many times.\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace\n\n    spec = Fly(2 * ~Linspace.bounded(\"x\", 3, 4, 1))\n\nIf you want snaked axes to have no gap between iterations you can do:\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace, Product\n\n    spec = Fly(Product(2, ~Linspace.bounded(\"x\", 3, 4, 1), gap=False))\n\n.. note:: There is no turnaround arrow at x=4",
             "properties": {
               "outer": {
-                "$ref": "#/$defs/Spec",
-                "description": "Will be executed once"
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Spec"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ],
+                "description": "Will be executed once",
+                "title": "Outer"
               },
               "inner": {
-                "$ref": "#/$defs/Spec",
-                "description": "Will be executed len(outer) times"
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Spec"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ],
+                "description": "Will be executed len(outer) times",
+                "title": "Inner"
+              },
+              "gap": {
+                "default": true,
+                "description": "If False and the outer spec is an integer and the inner spec is snaked then the end and start of consecutive iterations of inner will have no gap",
+                "title": "Gap",
+                "type": "boolean"
               },
               "type": {
                 "const": "Product",
@@ -406,22 +1724,40 @@
           },
           "Range_Reference_": {
             "additionalProperties": false,
-            "description": "Mask contains points of axis >= min and <= max.\n\n>>> r = Range(\"x\", 1, 2)\n>>> r.mask({\"x\": np.array([0, 1, 2, 3, 4])})\narray([False,  True,  True, False, False])",
+            "description": "Linearly spaced frames with start and stop as the bounding midpoints.\n\n``step`` defines the distance between midpoints.\n\n.. seealso::\n    `Linspace`: For linearly spaced frames defined with a number of frames.\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Range\n\n    spec = Fly(Range(\"x\", 1, 2, 0.25))",
             "properties": {
               "axis": {
-                "description": "The name matching the axis to mask in spec",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
+                "description": "An identifier for what to move",
+                "enum": [
+                  "attenuator",
+                  "base_y",
+                  "blower_z",
+                  "cobra",
+                  "cryostream",
+                  "env_x",
+                  "f2y",
+                  "fast_shutter",
+                  "hutch_shutter",
+                  "robot",
+                  "tth"
+                ],
                 "title": "Axis",
                 "type": "bluesky.protocols.Movable"
               },
-              "min": {
-                "description": "The minimum inclusive value in the region",
-                "title": "Min",
+              "start": {
+                "description": "Midpoint of the first point of the line",
+                "title": "Start",
                 "type": "number"
               },
-              "max": {
-                "description": "The minimum inclusive value in the region",
-                "title": "Max",
+              "stop": {
+                "description": "Midpoint of the last point of the line",
+                "title": "Stop",
+                "type": "number"
+              },
+              "step": {
+                "description": "Step size (defaults to stop - start)",
+                "exclusiveMinimum": 0,
+                "title": "Step",
                 "type": "number"
               },
               "type": {
@@ -431,149 +1767,13 @@
                 "type": "string"
               }
             },
-            "required": ["axis", "min", "max"],
+            "required": ["axis", "start", "stop"],
             "title": "Range",
-            "type": "object"
-          },
-          "Rectangle_Reference_": {
-            "additionalProperties": false,
-            "description": "Mask contains points of axis within a rotated xy rectangle.\n\n.. example_spec::\n\n    from scanspec.regions import Rectangle\n    from scanspec.specs import Line\n\n    grid = Line(\"y\", 1, 3, 10) * ~Line(\"x\", 0, 2, 10)\n    spec = grid & Rectangle(\"x\", \"y\", 0, 1.1, 1.5, 2.1, 30)",
-            "properties": {
-              "x_axis": {
-                "description": "The name matching the x axis of the spec",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
-                "title": "X Axis",
-                "type": "bluesky.protocols.Movable"
-              },
-              "y_axis": {
-                "description": "The name matching the y axis of the spec",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
-                "title": "Y Axis",
-                "type": "bluesky.protocols.Movable"
-              },
-              "x_min": {
-                "description": "Minimum inclusive x value in the region",
-                "title": "X Min",
-                "type": "number"
-              },
-              "y_min": {
-                "description": "Minimum inclusive y value in the region",
-                "title": "Y Min",
-                "type": "number"
-              },
-              "x_max": {
-                "description": "Maximum inclusive x value in the region",
-                "title": "X Max",
-                "type": "number"
-              },
-              "y_max": {
-                "description": "Maximum inclusive y value in the region",
-                "title": "Y Max",
-                "type": "number"
-              },
-              "angle": {
-                "default": 0,
-                "description": "Clockwise rotation angle of the rectangle",
-                "title": "Angle",
-                "type": "number"
-              },
-              "type": {
-                "const": "Rectangle",
-                "default": "Rectangle",
-                "title": "Type",
-                "type": "string"
-              }
-            },
-            "required": [
-              "x_axis",
-              "y_axis",
-              "x_min",
-              "y_min",
-              "x_max",
-              "y_max"
-            ],
-            "title": "Rectangle",
-            "type": "object"
-          },
-          "Region": {
-            "discriminator": {
-              "mapping": {
-                "Circle": "#/$defs/Circle_Reference_",
-                "CombinationOf": "#/$defs/CombinationOf_Reference_",
-                "DifferenceOf": "#/$defs/DifferenceOf_Reference_",
-                "Ellipse": "#/$defs/Ellipse_Reference_",
-                "IntersectionOf": "#/$defs/IntersectionOf_Reference_",
-                "Polygon": "#/$defs/Polygon_Reference_",
-                "Range": "#/$defs/Range_Reference_",
-                "Rectangle": "#/$defs/Rectangle_Reference_",
-                "SymmetricDifferenceOf": "#/$defs/SymmetricDifferenceOf_Reference_",
-                "UnionOf": "#/$defs/UnionOf_Reference_"
-              },
-              "propertyName": "type"
-            },
-            "oneOf": [
-              {
-                "$ref": "#/$defs/Range_Reference_"
-              },
-              {
-                "$ref": "#/$defs/Rectangle_Reference_"
-              },
-              {
-                "$ref": "#/$defs/Polygon_Reference_"
-              },
-              {
-                "$ref": "#/$defs/Circle_Reference_"
-              },
-              {
-                "$ref": "#/$defs/Ellipse_Reference_"
-              },
-              {
-                "$ref": "#/$defs/CombinationOf_Reference_"
-              },
-              {
-                "$ref": "#/$defs/UnionOf_Reference_"
-              },
-              {
-                "$ref": "#/$defs/IntersectionOf_Reference_"
-              },
-              {
-                "$ref": "#/$defs/DifferenceOf_Reference_"
-              },
-              {
-                "$ref": "#/$defs/SymmetricDifferenceOf_Reference_"
-              }
-            ]
-          },
-          "Repeat_Reference_": {
-            "additionalProperties": false,
-            "description": "Repeat an empty frame num times.\n\nCan be used on the outside of a scan to repeat the same scan many times.\n\n.. example_spec::\n\n    from scanspec.specs import Line\n\n    spec = 2 * ~Line.bounded(\"x\", 3, 4, 1)\n\nIf you want snaked axes to have no gap between iterations you can do:\n\n.. example_spec::\n\n    from scanspec.specs import Line, Repeat\n\n    spec = Repeat(2, gap=False) * ~Line.bounded(\"x\", 3, 4, 1)\n\n.. note:: There is no turnaround arrow at x=4",
-            "properties": {
-              "num": {
-                "description": "Number of frames to produce",
-                "minimum": 1,
-                "title": "Num",
-                "type": "integer"
-              },
-              "gap": {
-                "default": true,
-                "description": "If False and the slowest of the stack of Frames is snaked then the end and start of consecutive iterations of Spec will have no gap",
-                "title": "Gap",
-                "type": "boolean"
-              },
-              "type": {
-                "const": "Repeat",
-                "default": "Repeat",
-                "title": "Type",
-                "type": "string"
-              }
-            },
-            "required": ["num"],
-            "title": "Repeat",
             "type": "object"
           },
           "Snake_Reference_": {
             "additionalProperties": false,
-            "description": "Run the Spec in reverse on every other iteration when nested.\n\nTypically created with the ``~`` operator.\n\n.. example_spec::\n\n    from scanspec.specs import Line\n\n    spec = Line(\"y\", 1, 3, 3) * ~Line(\"x\", 3, 5, 5)",
+            "description": "Run the Spec in reverse on every other iteration when nested.\n\nTypically created with the ``~`` operator.\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace\n\n    spec = Fly(Linspace(\"y\", 1, 3, 3) * ~Linspace(\"x\", 3, 5, 5))",
             "properties": {
               "spec": {
                 "$ref": "#/$defs/Spec",
@@ -594,10 +1794,13 @@
             "discriminator": {
               "mapping": {
                 "Concat": "#/$defs/Concat_Reference_",
-                "Line": "#/$defs/Line_Reference_",
-                "Mask": "#/$defs/Mask_Reference_",
+                "ConstantDuration": "#/$defs/ConstantDuration_Reference_",
+                "Ellipse": "#/$defs/Ellipse_Reference_",
+                "Fly": "#/$defs/Fly_Reference_",
+                "Linspace": "#/$defs/Linspace_Reference_",
+                "Polygon": "#/$defs/Polygon_Reference_",
                 "Product": "#/$defs/Product_Reference_",
-                "Repeat": "#/$defs/Repeat_Reference_",
+                "Range": "#/$defs/Range_Reference_",
                 "Snake": "#/$defs/Snake_Reference_",
                 "Spiral": "#/$defs/Spiral_Reference_",
                 "Squash": "#/$defs/Squash_Reference_",
@@ -608,22 +1811,7 @@
             },
             "oneOf": [
               {
-                "$ref": "#/$defs/Line_Reference_"
-              },
-              {
-                "$ref": "#/$defs/Static_Reference_"
-              },
-              {
-                "$ref": "#/$defs/Squash_Reference_"
-              },
-              {
-                "$ref": "#/$defs/Spiral_Reference_"
-              },
-              {
                 "$ref": "#/$defs/Product_Reference_"
-              },
-              {
-                "$ref": "#/$defs/Repeat_Reference_"
               },
               {
                 "$ref": "#/$defs/Zip_Reference_"
@@ -635,56 +1823,97 @@
                 "$ref": "#/$defs/Concat_Reference_"
               },
               {
-                "$ref": "#/$defs/Mask_Reference_"
+                "$ref": "#/$defs/Squash_Reference_"
+              },
+              {
+                "$ref": "#/$defs/Linspace_Reference_"
+              },
+              {
+                "$ref": "#/$defs/Range_Reference_"
+              },
+              {
+                "$ref": "#/$defs/Fly_Reference_"
+              },
+              {
+                "$ref": "#/$defs/ConstantDuration_Reference_"
+              },
+              {
+                "$ref": "#/$defs/Static_Reference_"
+              },
+              {
+                "$ref": "#/$defs/Spiral_Reference_"
+              },
+              {
+                "$ref": "#/$defs/Ellipse_Reference_"
+              },
+              {
+                "$ref": "#/$defs/Polygon_Reference_"
               }
             ]
           },
           "Spiral_Reference_": {
             "additionalProperties": false,
-            "description": "Archimedean spiral of \"x_axis\" and \"y_axis\".\n\nStarts at centre point (\"x_start\", \"y_start\") with angle \"rotate\". Produces\n\"num\" points in a spiral spanning width of \"x_range\" and height of \"y_range\"\n\n.. example_spec::\n\n    from scanspec.specs import Spiral\n\n    spec = Spiral(\"x\", \"y\", 1, 5, 10, 50, 30)",
+            "description": "Archimedean spiral of \"x_axis\" and \"y_axis\".\n\nStarts at centre point (\"x_start\", \"y_start\")\". Produces \"num\" points in a\nspiral spanning width of \"x_range\" and height of \"y_range\"\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Spiral\n\n    spec = Fly(Spiral(\"x\", 1, 10, 2.5, \"y\", 5, 50))",
             "properties": {
               "x_axis": {
                 "description": "An identifier for what to move for x",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
+                "enum": [
+                  "attenuator",
+                  "base_y",
+                  "blower_z",
+                  "cobra",
+                  "cryostream",
+                  "env_x",
+                  "f2y",
+                  "fast_shutter",
+                  "hutch_shutter",
+                  "robot",
+                  "tth"
+                ],
                 "title": "X Axis",
                 "type": "bluesky.protocols.Movable"
               },
+              "x_centre": {
+                "description": "x centre of the spiral",
+                "title": "X Centre",
+                "type": "number"
+              },
+              "x_diameter": {
+                "description": "x width of the spiral",
+                "title": "X Diameter",
+                "type": "number"
+              },
+              "x_step": {
+                "description": "Radial spacing along x",
+                "title": "X Step",
+                "type": "number"
+              },
               "y_axis": {
                 "description": "An identifier for what to move for y",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
+                "enum": [
+                  "attenuator",
+                  "base_y",
+                  "blower_z",
+                  "cobra",
+                  "cryostream",
+                  "env_x",
+                  "f2y",
+                  "fast_shutter",
+                  "hutch_shutter",
+                  "robot",
+                  "tth"
+                ],
                 "title": "Y Axis",
                 "type": "bluesky.protocols.Movable"
               },
-              "x_start": {
-                "description": "x centre of the spiral",
-                "title": "X Start",
-                "type": "number"
-              },
-              "y_start": {
+              "y_centre": {
                 "description": "y centre of the spiral",
-                "title": "Y Start",
+                "title": "Y Centre",
                 "type": "number"
               },
-              "x_range": {
-                "description": "x width of the spiral",
-                "title": "X Range",
-                "type": "number"
-              },
-              "y_range": {
-                "description": "y width of the spiral",
-                "title": "Y Range",
-                "type": "number"
-              },
-              "num": {
-                "description": "Number of frames to produce",
-                "minimum": 1,
-                "title": "Num",
-                "type": "integer"
-              },
-              "rotate": {
-                "default": 0,
-                "description": "How much to rotate the angle of the spiral",
-                "title": "Rotate",
+              "y_diameter": {
+                "description": "y width of the spiral (defaults to x_diameter)",
+                "title": "Y Diameter",
                 "type": "number"
               },
               "type": {
@@ -696,19 +1925,18 @@
             },
             "required": [
               "x_axis",
+              "x_centre",
+              "x_diameter",
+              "x_step",
               "y_axis",
-              "x_start",
-              "y_start",
-              "x_range",
-              "y_range",
-              "num"
+              "y_centre"
             ],
             "title": "Spiral",
             "type": "object"
           },
           "Squash_Reference_": {
             "additionalProperties": false,
-            "description": "Squash a stack of Frames together into a single expanded Frames object.\n\nSee Also:\n    `why-squash-can-change-path`\n\n.. example_spec::\n\n    from scanspec.specs import Line, Squash\n\n    spec = Squash(Line(\"y\", 1, 2, 3) * Line(\"x\", 0, 1, 4))",
+            "description": "Squash a stack of Dimension together into a single expanded Dimension object.\n\nSee Also:\n    `why-squash-can-change-path`\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace, Squash\n\n    spec = Fly(Squash(Linspace(\"y\", 1, 2, 3) * Linspace(\"x\", 0, 1, 4)))",
             "properties": {
               "spec": {
                 "$ref": "#/$defs/Spec",
@@ -733,11 +1961,23 @@
           },
           "Static_Reference_": {
             "additionalProperties": false,
-            "description": "A static frame, repeated num times, with axis at value.\n\nCan be used to set axis=value at every point in a scan.\n\n.. example_spec::\n\n    from scanspec.specs import Line, Static\n\n    spec = Line(\"y\", 1, 2, 3).zip(Static(\"x\", 3))",
+            "description": "A static frame, repeated num times, with axis at value.\n\nCan be used to set axis=value at every point in a scan.\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace, Static\n\n    spec = Fly(Linspace(\"y\", 1, 2, 3).zip(Static(\"x\", 3)))",
             "properties": {
               "axis": {
                 "description": "An identifier for what to move",
-                "enum": ["sample_stage.x", "sample_stage.y", "sample_stage.z"],
+                "enum": [
+                  "attenuator",
+                  "base_y",
+                  "blower_z",
+                  "cobra",
+                  "cryostream",
+                  "env_x",
+                  "f2y",
+                  "fast_shutter",
+                  "hutch_shutter",
+                  "robot",
+                  "tth"
+                ],
                 "title": "Axis",
                 "type": "bluesky.protocols.Movable"
               },
@@ -764,55 +2004,9 @@
             "title": "Static",
             "type": "object"
           },
-          "SymmetricDifferenceOf_Reference_": {
-            "additionalProperties": false,
-            "description": "A point is in SymmetricDifferenceOf(a, b) if in either a or b, but not both.\n\nTypically created with the ``^`` operator.\n\n>>> r = Range(\"x\", 0.5, 2.5) ^ Range(\"x\", 1.5, 3.5)\n>>> r.mask({\"x\": np.array([0, 1, 2, 3, 4])})\narray([False,  True, False,  True, False])",
-            "properties": {
-              "left": {
-                "$ref": "#/$defs/Region",
-                "description": "The left-hand Region to combine"
-              },
-              "right": {
-                "$ref": "#/$defs/Region",
-                "description": "The right-hand Region to combine"
-              },
-              "type": {
-                "const": "SymmetricDifferenceOf",
-                "default": "SymmetricDifferenceOf",
-                "title": "Type",
-                "type": "string"
-              }
-            },
-            "required": ["left", "right"],
-            "title": "SymmetricDifferenceOf",
-            "type": "object"
-          },
-          "UnionOf_Reference_": {
-            "additionalProperties": false,
-            "description": "A point is in UnionOf(a, b) if in either a or b.\n\nTypically created with the ``|`` operator\n\n>>> r = Range(\"x\", 0.5, 2.5) | Range(\"x\", 1.5, 3.5)\n>>> r.mask({\"x\": np.array([0, 1, 2, 3, 4])})\narray([False,  True,  True,  True, False])",
-            "properties": {
-              "left": {
-                "$ref": "#/$defs/Region",
-                "description": "The left-hand Region to combine"
-              },
-              "right": {
-                "$ref": "#/$defs/Region",
-                "description": "The right-hand Region to combine"
-              },
-              "type": {
-                "const": "UnionOf",
-                "default": "UnionOf",
-                "title": "Type",
-                "type": "string"
-              }
-            },
-            "required": ["left", "right"],
-            "title": "UnionOf",
-            "type": "object"
-          },
           "Zip_Reference_": {
             "additionalProperties": false,
-            "description": "Run two Specs in parallel, merging their midpoints together.\n\nTypically formed using `Spec.zip`.\n\nStacks of Frames are merged by:\n\n- If right creates a stack of a single Frames object of size 1, expand it to\n  the size of the fastest Frames object created by left\n- Merge individual Frames objects together from fastest to slowest\n\nThis means that Zipping a Spec producing stack [l2, l1] with a Spec\nproducing stack [r1] will assert len(l1)==len(r1), and produce\nstack [l2, l1.zip(r1)].\n\n.. example_spec::\n\n    from scanspec.specs import Line\n\n    spec = Line(\"z\", 1, 2, 3) * Line(\"y\", 3, 4, 5).zip(Line(\"x\", 4, 5, 5))",
+            "description": "Run two Specs in parallel, merging their midpoints together.\n\nTypically formed using `Spec.zip`.\n\nStacks of Dimension are merged by:\n\n- If right creates a stack of a single Dimension object of size 1, expand it to\n  the size of the fastest Dimension object created by left\n- Merge individual Dimension objects together from fastest to slowest\n\nThis means that Zipping a Spec producing stack [l2, l1] with a Spec\nproducing stack [r1] will assert len(l1)==len(r1), and produce\nstack [l2, l1.zip(r1)].\n\n.. example_spec::\n\n    from scanspec.specs import Fly, Linspace\n\n    spec = Fly(\n        Linspace(\"z\", 1, 2, 3) * Linspace(\"y\", 3, 4, 5).zip(Linspace(\"x\", 4, 5, 5))\n    )",
             "properties": {
               "left": {
                 "$ref": "#/$defs/Spec",
@@ -839,11 +2033,42 @@
           "detectors": {
             "items": {
               "enum": [
-                "sample_stage",
-                "sample_det",
-                "oav",
+                "att_y",
+                "attenuator",
+                "base_y",
+                "blower_z",
+                "bs2",
+                "cam_1",
+                "cam_2",
+                "cam_3",
+                "cobra",
+                "cryostream",
+                "det2",
+                "env_x",
+                "f2y",
+                "fast_shutter",
+                "fastcs_eiger",
+                "gonio_interlock",
+                "hexapod",
+                "hexapod_rotation",
+                "hutch_interlock",
+                "hutch_shutter",
+                "i0",
+                "m1",
+                "puck_detect",
+                "rail",
+                "robot",
+                "slits_2",
+                "slits_3",
+                "slits_4",
+                "slits_5",
                 "synchrotron",
-                "panda"
+                "trans",
+                "tth",
+                "webcam_1",
+                "webcam_2",
+                "xtal",
+                "zebra"
               ],
               "type": "bluesky.protocols.Readable"
             },
@@ -855,12 +2080,1288 @@
             "$ref": "#/$defs/Spec"
           },
           "metadata": {
+            "additionalProperties": true,
             "title": "Metadata",
             "type": "object"
           }
         },
         "required": ["detectors", "spec"],
         "title": "spec_scan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "step_grid_rscan",
+      "description": "Scan independent trajectories with specified step size, relative to position.\n\n    Generates list(s) of points for each trajectory, used with\n    bluesky.plans.list_grid_scan(det, *args, md=metadata). Snakes all fast axes by\n    default (all axes but the first axis provided).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "snake_axes": {
+            "title": "Snake Axes",
+            "type": "boolean"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "step_grid_rscan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "step_grid_scan",
+      "description": "Scan independent trajectories with specified step size.\n\n    Generates list(s) of points for each trajectory, used with\n    bluesky.plans.list_grid_scan(det, *args, md=metadata). Snakes all fast axes by\n    default (all axes but the first axis provided).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "snake_axes": {
+            "title": "Snake Axes",
+            "type": "boolean"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "step_grid_scan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "step_rscan",
+      "description": "Scan concurrent trajectories with specified step size, relative to position.\n\n    Generates list(s) of points for each trajectory, used with\n    bluesky.plans.rel_list_scan(det, *args, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "step_rscan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "step_scan",
+      "description": "Scan concurrent trajectories with specified step size.\n\n    Generates list(s) of points for each trajectory, used with\n    bluesky.plans.list_scan(det, *args, md=metadata).\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "detectors": {
+            "items": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "bluesky.protocols.Readable"
+                },
+                {
+                  "enum": [
+                    "att_y",
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "bs2",
+                    "cam_1",
+                    "cam_2",
+                    "cam_3",
+                    "cobra",
+                    "cryostream",
+                    "det2",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "fastcs_eiger",
+                    "gonio_interlock",
+                    "hexapod",
+                    "hexapod_rotation",
+                    "hutch_interlock",
+                    "hutch_shutter",
+                    "i0",
+                    "m1",
+                    "puck_detect",
+                    "rail",
+                    "robot",
+                    "slits_2",
+                    "slits_3",
+                    "slits_4",
+                    "slits_5",
+                    "synchrotron",
+                    "trans",
+                    "tth",
+                    "webcam_1",
+                    "webcam_2",
+                    "xtal",
+                    "zebra"
+                  ],
+                  "type": "ophyd_async.core._protocol.AsyncReadable"
+                }
+              ]
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "params": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "enum": [
+                    "attenuator",
+                    "base_y",
+                    "blower_z",
+                    "cobra",
+                    "cryostream",
+                    "env_x",
+                    "f2y",
+                    "fast_shutter",
+                    "hutch_shutter",
+                    "robot",
+                    "tth"
+                  ],
+                  "type": "bluesky.protocols.Movable"
+                },
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Params",
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": ["detectors", "params"],
+        "title": "step_scan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "move",
+      "description": "Move a device, wrapper for `bp.mv`.\n\n    Args:\n        moves (Mapping[Movable, T]): Mapping of Movables to target positions.\n        group (Group | None, optional): The message group to associate with the setting,\n            for sequencing. Defaults to None.\n\n    Returns:\n        MsgGenerator: Plan.\n\n    Yields:\n        Iterator[MsgGenerator]: Bluesky messages.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "moves": {
+            "additionalProperties": true,
+            "title": "Moves",
+            "type": "object"
+          },
+          "group": {
+            "title": "Group",
+            "type": "string"
+          }
+        },
+        "required": ["moves"],
+        "title": "move",
+        "type": "object"
+      }
+    },
+    {
+      "name": "move_relative",
+      "description": "Move a device relative to its current position, wrapper for `bp.mvr`.\n\n    Args:\n        moves (Mapping[Movable, T]): Mapping of Movables to target deltas.\n        group (Group | None, optional): The message group to associate with the\n            setting, for sequencing. Defaults to None.\n\n    Returns:\n        MsgGenerator: Plan.\n\n    Yields:\n        Iterator[MsgGenerator]: Bluesky messages.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "moves": {
+            "additionalProperties": true,
+            "title": "Moves",
+            "type": "object"
+          },
+          "group": {
+            "title": "Group",
+            "type": "string"
+          }
+        },
+        "required": ["moves"],
+        "title": "move_relative",
+        "type": "object"
+      }
+    },
+    {
+      "name": "rd",
+      "description": "Reads a single-value non-triggered object, wrapper for `bps.rd`.\n\n    Args:\n        readable (Readable): The device to be read\n\n    Returns:\n        MsgGenerator: Plan.\n\n    Yields:\n        Iterator[MsgGenerator]: Bluesky messages.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "readable": {
+            "enum": [
+              "att_y",
+              "attenuator",
+              "base_y",
+              "blower_z",
+              "bs2",
+              "cam_1",
+              "cam_2",
+              "cam_3",
+              "cobra",
+              "cryostream",
+              "det2",
+              "env_x",
+              "f2y",
+              "fast_shutter",
+              "fastcs_eiger",
+              "gonio_interlock",
+              "hexapod",
+              "hexapod_rotation",
+              "hutch_interlock",
+              "hutch_shutter",
+              "i0",
+              "m1",
+              "puck_detect",
+              "rail",
+              "robot",
+              "slits_2",
+              "slits_3",
+              "slits_4",
+              "slits_5",
+              "synchrotron",
+              "trans",
+              "tth",
+              "webcam_1",
+              "webcam_2",
+              "xtal",
+              "zebra"
+            ],
+            "title": "Readable",
+            "type": "bluesky.protocols.Readable"
+          }
+        },
+        "required": ["readable"],
+        "title": "rd",
+        "type": "object"
+      }
+    },
+    {
+      "name": "set_absolute",
+      "description": "Set a device, wrapper for `bp.abs_set`.\n\n    Args:\n        movable (Movable[T]): The device to set.\n        value (T): The new value.\n        group (Group | None, optional): The message group to associate with the setting,\n            for sequencing. Defaults to None.\n        wait (bool, optional): The group should wait until all setting is complete (e.g.\n            a motor has finished moving). Defaults to False.\n\n    Returns:\n        MsgGenerator: Plan.\n\n    Yields:\n        Iterator[MsgGenerator]: Bluesky messages.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "movable": {
+            "enum": [
+              "attenuator",
+              "base_y",
+              "blower_z",
+              "cobra",
+              "cryostream",
+              "env_x",
+              "f2y",
+              "fast_shutter",
+              "hutch_shutter",
+              "robot",
+              "tth"
+            ],
+            "title": "Movable",
+            "type": "bluesky.protocols.Movable",
+            "types": ["Any"]
+          },
+          "value": {
+            "title": "Value"
+          },
+          "group": {
+            "title": "Group",
+            "type": "string"
+          },
+          "wait": {
+            "title": "Wait",
+            "type": "boolean"
+          }
+        },
+        "required": ["movable", "value"],
+        "title": "set_absolute",
+        "type": "object"
+      }
+    },
+    {
+      "name": "set_relative",
+      "description": "Change a device, wrapper for `bp.rel_set`.\n\n    Args:\n        movable (Movable): The device to set.\n        value (T): The new value.\n        group (Group | None, optional): The message group to associate with the setting,\n            for sequencing. Defaults to None.\n        wait (bool, optional): The group should wait until all setting is complete (e.g.\n            a motor has finished moving). Defaults to False.\n\n    Returns:\n        MsgGenerator: Plan.\n\n    Yields:\n        Iterator[MsgGenerator]: Bluesky messages.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "movable": {
+            "enum": [
+              "attenuator",
+              "base_y",
+              "blower_z",
+              "cobra",
+              "cryostream",
+              "env_x",
+              "f2y",
+              "fast_shutter",
+              "hutch_shutter",
+              "robot",
+              "tth"
+            ],
+            "title": "Movable",
+            "type": "bluesky.protocols.Movable",
+            "types": ["Any"]
+          },
+          "value": {
+            "title": "Value"
+          },
+          "group": {
+            "title": "Group",
+            "type": "string"
+          },
+          "wait": {
+            "title": "Wait",
+            "type": "boolean"
+          }
+        },
+        "required": ["movable", "value"],
+        "title": "set_relative",
+        "type": "object"
+      }
+    },
+    {
+      "name": "sleep",
+      "description": "Suspend all action for a given time, wrapper for `bp.sleep`.\n\n    Args:\n        time (float): Time to wait in seconds.\n\n    Returns:\n        MsgGenerator: Plan.\n\n    Yields:\n        Iterator[MsgGenerator]: Bluesky messages.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "time": {
+            "title": "Time",
+            "type": "number"
+          }
+        },
+        "required": ["time"],
+        "title": "sleep",
+        "type": "object"
+      }
+    },
+    {
+      "name": "stop",
+      "description": "Stop a device, wrapper for `bps.stop`.\n\n    Args:\n        stoppable (Stoppable): Device to be stopped\n\n    Returns:\n        MsgGenerator: Plan.\n\n    Yields:\n        Iterator[MsgGenerator]: Bluesky messages.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "stoppable": {
+            "enum": ["base_y", "env_x", "f2y", "tth"],
+            "title": "Stoppable",
+            "type": "bluesky.protocols.Stoppable"
+          }
+        },
+        "required": ["stoppable"],
+        "title": "stop",
+        "type": "object"
+      }
+    },
+    {
+      "name": "wait",
+      "description": "Wait for a group status to complete, wrapper for `bp.wait`.\n    Does not expose move_on, as when used as a stub will not fail on Timeout.\n\n    Args:\n        group (Group | None, optional): The name of the group to wait for, defaults to\n            None, in which case waits for all groups that have not yet been awaited.\n        timeout (float | None, default=None): a timeout in seconds.\n\n    Returns:\n        MsgGenerator: Plan.\n\n    Yields:\n        Iterator[MsgGenerator]: Bluesky messages.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "group": {
+            "title": "Group",
+            "type": "string"
+          },
+          "timeout": {
+            "title": "Timeout",
+            "type": "number"
+          }
+        },
+        "title": "wait",
+        "type": "object"
+      }
+    },
+    {
+      "name": "robot_load",
+      "description": null,
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "puck": {
+            "title": "Puck",
+            "type": "integer"
+          },
+          "position": {
+            "title": "Position",
+            "type": "integer"
+          },
+          "robot": {
+            "enum": ["robot"],
+            "title": "Robot",
+            "type": "dodal.devices.beamlines.i15_1.robot.Robot"
+          },
+          "hutch_interlock": {
+            "enum": ["hutch_interlock"],
+            "title": "Hutch Interlock",
+            "type": "dodal.devices.interlocks.PSSInterlock"
+          },
+          "gonio_interlock": {
+            "enum": ["gonio_interlock"],
+            "title": "Gonio Interlock",
+            "type": "dodal.devices.interlocks.IntPLCInterlock"
+          },
+          "hexapod": {
+            "enum": ["hexapod", "hexapod_rotation"],
+            "title": "Hexapod",
+            "type": "dodal.devices.motors.XYZStage"
+          },
+          "hexapod_rotation": {
+            "enum": ["hexapod", "hexapod_rotation"],
+            "title": "Hexapod Rotation",
+            "type": "dodal.devices.motors.XYZStage"
+          },
+          "blower": {
+            "enum": ["blower_z"],
+            "title": "Blower",
+            "type": "dodal.devices.beamlines.i15_1.blower.Blower"
+          },
+          "cobra": {
+            "enum": ["cobra"],
+            "title": "Cobra",
+            "type": "dodal.devices.beamlines.i15_1.cobra.Cobra"
+          }
+        },
+        "required": ["puck", "position"],
+        "title": "robot_load",
+        "type": "object"
+      }
+    },
+    {
+      "name": "move_hexapod_to_home_position",
+      "description": null,
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "hexapod": {
+            "enum": ["hexapod", "hexapod_rotation"],
+            "title": "Hexapod",
+            "type": "dodal.devices.motors.XYZStage"
+          },
+          "hexapod_rotation": {
+            "enum": ["hexapod", "hexapod_rotation"],
+            "title": "Hexapod Rotation",
+            "type": "dodal.devices.motors.XYZStage"
+          },
+          "x_home": {
+            "title": "X Home",
+            "type": "number"
+          },
+          "y_home": {
+            "title": "Y Home",
+            "type": "number"
+          },
+          "z_home": {
+            "title": "Z Home",
+            "type": "number"
+          },
+          "rx_home": {
+            "title": "Rx Home",
+            "type": "number"
+          },
+          "ry_home": {
+            "title": "Ry Home",
+            "type": "number"
+          },
+          "rz_home": {
+            "title": "Rz Home",
+            "type": "number"
+          },
+          "group": {
+            "title": "Group",
+            "type": "string"
+          }
+        },
+        "title": "move_hexapod_to_home_position",
+        "type": "object"
+      }
+    },
+    {
+      "name": "prepare_beamline_for_robot_load",
+      "description": null,
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "blower": {
+            "enum": ["blower_z"],
+            "title": "Blower",
+            "type": "dodal.devices.beamlines.i15_1.blower.Blower"
+          },
+          "cobra": {
+            "enum": ["cobra"],
+            "title": "Cobra",
+            "type": "dodal.devices.beamlines.i15_1.cobra.Cobra"
+          }
+        },
+        "title": "prepare_beamline_for_robot_load",
+        "type": "object"
+      }
+    },
+    {
+      "name": "robot_unload",
+      "description": null,
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "robot": {
+            "enum": ["robot"],
+            "title": "Robot",
+            "type": "dodal.devices.beamlines.i15_1.robot.Robot"
+          },
+          "hutch_interlock": {
+            "enum": ["hutch_interlock"],
+            "title": "Hutch Interlock",
+            "type": "dodal.devices.interlocks.PSSInterlock"
+          },
+          "gonio_interlock": {
+            "enum": ["gonio_interlock"],
+            "title": "Gonio Interlock",
+            "type": "dodal.devices.interlocks.IntPLCInterlock"
+          },
+          "hexapod": {
+            "enum": ["hexapod", "hexapod_rotation"],
+            "title": "Hexapod",
+            "type": "dodal.devices.motors.XYZStage"
+          },
+          "hexapod_rotation": {
+            "enum": ["hexapod", "hexapod_rotation"],
+            "title": "Hexapod Rotation",
+            "type": "dodal.devices.motors.XYZStage"
+          }
+        },
+        "title": "robot_unload",
+        "type": "object"
+      }
+    },
+    {
+      "name": "take_snapshot",
+      "description": null,
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "camera": {
+            "enum": ["cam_1", "cam_2", "cam_3", "webcam_1", "webcam_2"],
+            "title": "Camera",
+            "type": "ophyd_async.epics.adcore._detector.ContAcqDetector"
+          }
+        },
+        "required": ["camera"],
+        "title": "take_snapshot",
+        "type": "object"
+      }
+    },
+    {
+      "name": "static_collection_plan",
+      "description": "Take a static collection with the eiger and i0 detectors. Currently the i0 is\n    triggered by the zebra and the eiger is triggered manually. Metadata from the robot\n    spinner, tth, and any other baseline devices will be added to the nexus file.\n\n    Args:\n        frames (int): Number of frames to capture\n        exposure_time (float): Exposure time of each frame\n        eiger (EigerDetector, optional): FastCS eiger device.\n        i0 (TetrammDetector, optional): i0 device.\n        zebra (Zebra, optional): Zebra device.\n        robot (Robot, optional): Robot device, needed for spinner metadata.\n        tth (Motor, optional): Two theta device, needed for eiger angle metadata.\n        baseline_devices (list[StandardReadable] | None, optional): Any other devices to\n        record metadata from. Defaults to None.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "frames": {
+            "title": "Frames",
+            "type": "integer"
+          },
+          "exposure_time": {
+            "title": "Exposure Time",
+            "type": "number"
+          },
+          "eiger": {
+            "enum": ["fastcs_eiger"],
+            "title": "Eiger",
+            "type": "ophyd_async.fastcs.eiger._detector.EigerDetector"
+          },
+          "i0": {
+            "enum": ["i0"],
+            "title": "I0",
+            "type": "dodal.devices.tetramm.TetrammDetector"
+          },
+          "zebra": {
+            "enum": ["zebra"],
+            "title": "Zebra",
+            "type": "dodal.devices.zebra.zebra.Zebra"
+          },
+          "robot": {
+            "enum": ["robot"],
+            "title": "Robot",
+            "type": "dodal.devices.beamlines.i15_1.robot.Robot"
+          },
+          "tth": {
+            "enum": ["base_y", "env_x", "f2y", "tth"],
+            "title": "Tth",
+            "type": "ophyd_async.epics.motor.Motor"
+          },
+          "xtal": {
+            "enum": ["xtal"],
+            "title": "Xtal",
+            "type": "dodal.devices.beamlines.i15_1.laue.LaueMonochrometer"
+          },
+          "baseline_devices": {
+            "items": {
+              "enum": [
+                "att_y",
+                "attenuator",
+                "base_y",
+                "blower_z",
+                "bs2",
+                "cobra",
+                "cryostream",
+                "det2",
+                "env_x",
+                "f2y",
+                "fast_shutter",
+                "gonio_interlock",
+                "hexapod",
+                "hexapod_rotation",
+                "hutch_interlock",
+                "hutch_shutter",
+                "m1",
+                "puck_detect",
+                "rail",
+                "robot",
+                "slits_2",
+                "slits_3",
+                "slits_4",
+                "slits_5",
+                "synchrotron",
+                "trans",
+                "tth",
+                "xtal",
+                "zebra"
+              ],
+              "type": "ophyd_async.core._readable.StandardReadable"
+            },
+            "title": "Baseline Devices",
+            "type": "array"
+          }
+        },
+        "required": ["frames", "exposure_time"],
+        "title": "static_collection_plan",
+        "type": "object"
+      }
+    },
+    {
+      "name": "static_collect_and_trigger_analysis",
+      "description": null,
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "frames": {
+            "title": "Frames",
+            "type": "integer"
+          },
+          "exposure_time": {
+            "title": "Exposure Time",
+            "type": "number"
+          },
+          "eiger": {
+            "enum": ["fastcs_eiger"],
+            "title": "Eiger",
+            "type": "ophyd_async.fastcs.eiger._detector.EigerDetector"
+          },
+          "i0": {
+            "enum": ["i0"],
+            "title": "I0",
+            "type": "dodal.devices.tetramm.TetrammDetector"
+          },
+          "zebra": {
+            "enum": ["zebra"],
+            "title": "Zebra",
+            "type": "dodal.devices.zebra.zebra.Zebra"
+          },
+          "robot": {
+            "enum": ["robot"],
+            "title": "Robot",
+            "type": "dodal.devices.beamlines.i15_1.robot.Robot"
+          },
+          "tth": {
+            "enum": ["base_y", "env_x", "f2y", "tth"],
+            "title": "Tth",
+            "type": "ophyd_async.epics.motor.Motor"
+          },
+          "xtal": {
+            "enum": ["xtal"],
+            "title": "Xtal",
+            "type": "dodal.devices.beamlines.i15_1.laue.LaueMonochrometer"
+          }
+        },
+        "required": ["frames", "exposure_time"],
+        "title": "static_collect_and_trigger_analysis",
+        "type": "object"
+      }
+    },
+    {
+      "name": "static_collection",
+      "description": "Take a static collection with the eiger and i0 detectors.\n\n    Args:\n        frames (int): Number of frames to capture\n        exposure_time (float): Exposure time of each frame\n        time_between_frames (float): The time between each frame\n        generic_collection_devices (GenericCollectionDevices, optional): The standard devices needed for the collection.\n        baseline_devices (list[StandardReadable] | None, optional): Any other devices to\n        record metadata from. Defaults to None.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "frames": {
+            "title": "Frames",
+            "type": "integer"
+          },
+          "exposure_time": {
+            "title": "Exposure Time",
+            "type": "number"
+          },
+          "time_between_frames": {
+            "title": "Time Between Frames",
+            "type": "number"
+          },
+          "baseline_devices": {
+            "items": {
+              "enum": [
+                "att_y",
+                "attenuator",
+                "base_y",
+                "blower_z",
+                "bs2",
+                "cobra",
+                "cryostream",
+                "det2",
+                "env_x",
+                "f2y",
+                "fast_shutter",
+                "gonio_interlock",
+                "hexapod",
+                "hexapod_rotation",
+                "hutch_interlock",
+                "hutch_shutter",
+                "m1",
+                "puck_detect",
+                "rail",
+                "robot",
+                "slits_2",
+                "slits_3",
+                "slits_4",
+                "slits_5",
+                "synchrotron",
+                "trans",
+                "tth",
+                "xtal",
+                "zebra"
+              ],
+              "type": "ophyd_async.core._readable.StandardReadable"
+            },
+            "title": "Baseline Devices",
+            "type": "array"
+          }
+        },
+        "required": ["frames", "exposure_time"],
+        "title": "static_collection",
+        "type": "object"
+      }
+    },
+    {
+      "name": "centre_sample",
+      "description": "Run a step scan in hexapod z, trigger analysis to find the centre and \n    move to the centre that is returned.\n\n    Args:\n        start_z (float): The start of the scan.\n        end_z (float): The end of the scan.\n        steps (int): The number of steps to scan across.\n        exposure_time (float): Exposure time of each frame.\n        generic_collection_devices (GenericCollectionDevices, optional): The standard devices needed for the collection.\n        hexapod (XYZStage, optional): The hexapod that is used to scan the sample.\n        baseline_devices (list[StandardReadable] | None, optional): Any other devices to\n        record metadata from. Defaults to None.\n    ",
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "start_z": {
+            "title": "Start Z",
+            "type": "number"
+          },
+          "end_z": {
+            "title": "End Z",
+            "type": "number"
+          },
+          "steps": {
+            "title": "Steps",
+            "type": "integer"
+          },
+          "exposure_time": {
+            "title": "Exposure Time",
+            "type": "number"
+          },
+          "hexapod": {
+            "enum": ["hexapod", "hexapod_rotation"],
+            "title": "Hexapod",
+            "type": "dodal.devices.motors.XYZStage"
+          },
+          "baseline_devices": {
+            "items": {
+              "enum": [
+                "att_y",
+                "attenuator",
+                "base_y",
+                "blower_z",
+                "bs2",
+                "cobra",
+                "cryostream",
+                "det2",
+                "env_x",
+                "f2y",
+                "fast_shutter",
+                "gonio_interlock",
+                "hexapod",
+                "hexapod_rotation",
+                "hutch_interlock",
+                "hutch_shutter",
+                "m1",
+                "puck_detect",
+                "rail",
+                "robot",
+                "slits_2",
+                "slits_3",
+                "slits_4",
+                "slits_5",
+                "synchrotron",
+                "trans",
+                "tth",
+                "xtal",
+                "zebra"
+              ],
+              "type": "ophyd_async.core._readable.StandardReadable"
+            },
+            "title": "Baseline Devices",
+            "type": "array"
+          }
+        },
+        "required": ["start_z", "end_z", "steps", "exposure_time"],
+        "title": "centre_sample",
         "type": "object"
       }
     }

--- a/packages/blueapi-ui/src/PlanParameters.tsx
+++ b/packages/blueapi-ui/src/PlanParameters.tsx
@@ -5,7 +5,7 @@ import {
   materialRenderers,
   materialCells,
 } from "@jsonforms/material-renderers";
-import { sanitisePlan } from "./utils/schema";
+import { sanitisePlan, type SchemaNode } from "./utils/schema";
 import type { Plan } from "@atlas/blueapi";
 import { RunPlanButton } from "./RunPlanButton";
 
@@ -13,6 +13,9 @@ import { ErrorBoundary } from "react-error-boundary";
 
 /**
  * If the UI generation fails, we show a simple apology
+ * TODO: This should instead be a JSON editor,
+ * ideally with an initial JSON object derived from the selected plan's schema
+ * See https://github.com/DiamondLightSource/atlas/issues/83
  */
 function UIFallback() {
   return (
@@ -50,13 +53,17 @@ export const PlanParameters: React.FC<PlanParametersProps> = (
             {props.plan.description}
           </Typography>
         )}
-        <JsonForms
-          schema={plan.schema}
-          data={planParameters}
-          renderers={materialRenderers}
-          cells={materialCells}
-          onChange={({ data }) => setPlanParameters(data)}
-        />
+        {(plan.schema as SchemaNode).skip ? (
+          <UIFallback />
+        ) : (
+          <JsonForms
+            schema={plan.schema}
+            data={planParameters}
+            renderers={materialRenderers}
+            cells={materialCells}
+            onChange={({ data }) => setPlanParameters(data)}
+          />
+        )}
       </Box>
       {/* TODO: Remove InstrumentSession box and state, retrieve from context when submitting.
                 See https://github.com/DiamondLightSource/atlas/issues/57 */}

--- a/packages/blueapi-ui/src/PlanParameters.tsx
+++ b/packages/blueapi-ui/src/PlanParameters.tsx
@@ -5,7 +5,7 @@ import {
   materialRenderers,
   materialCells,
 } from "@jsonforms/material-renderers";
-import sanitizeSchema from "./utils/schema";
+import { sanitisePlan } from "./utils/schema";
 import type { Plan } from "@atlas/blueapi";
 import { RunPlanButton } from "./RunPlanButton";
 
@@ -28,7 +28,7 @@ type PlanParametersProps = {
 export const PlanParameters: React.FC<PlanParametersProps> = (
   props: PlanParametersProps,
 ) => {
-  const schema = sanitizeSchema(props.plan.schema);
+  const plan = sanitisePlan(props.plan);
 
   const [planParameters, setPlanParameters] = useState({});
   // TODO: Remove InstrumentSession box and state, retrieve from context when submitting.
@@ -51,7 +51,7 @@ export const PlanParameters: React.FC<PlanParametersProps> = (
           </Typography>
         )}
         <JsonForms
-          schema={schema}
+          schema={plan.schema}
           data={planParameters}
           renderers={materialRenderers}
           cells={materialCells}

--- a/packages/blueapi-ui/src/utils/sanitisers.ts
+++ b/packages/blueapi-ui/src/utils/sanitisers.ts
@@ -13,9 +13,10 @@ const JSON_SCHEMA_TYPES = new Set([
 /** Replaces any unknown types for `string` when an enum field exists */
 export const replaceUnknownEnumTypes: Sanitiser = (node) => {
   if (
-    Array.isArray(node.enum) &&
-    typeof node.type === "string" &&
-    !JSON_SCHEMA_TYPES.has(node.type)
+    node.skip ||
+    (Array.isArray(node.enum) &&
+      typeof node.type === "string" &&
+      !JSON_SCHEMA_TYPES.has(node.type))
   ) {
     node.type = "string";
   }
@@ -23,7 +24,7 @@ export const replaceUnknownEnumTypes: Sanitiser = (node) => {
 };
 
 export const collapseAnyOfEnumBranches: Sanitiser = (node) => {
-  if (!Array.isArray(node.anyOf)) {
+  if (node.skip || !Array.isArray(node.anyOf)) {
     return node;
   }
 
@@ -45,4 +46,83 @@ export const collapseAnyOfEnumBranches: Sanitiser = (node) => {
   delete node.anyOf;
   node.type = "string";
   node.enum = values;
+};
+
+const isRecursiveSchema = (node: SchemaNode): boolean => {
+  // collect all definitions
+  const defs = node.$defs;
+  if (!defs || typeof defs !== "object") {
+    return false;
+  }
+
+  // build graph: definition -> referenced definitions
+  const graph = new Map<string, Set<string>>();
+  for (const [name, def] of Object.entries(defs)) {
+    graph.set(name, new Set());
+    visit(def, (node) => {
+      const ref = node.$ref;
+
+      // we only care about recursion among local definitions so we look for #/$defs/
+      if (typeof ref === "string" && ref.startsWith("#/$defs/")) {
+        const target = ref.substring("#/$defs/".length);
+        graph.get(name)!.add(target);
+      }
+    });
+  }
+
+  /** Nodes that have been completely processed */
+  const visited = new Set<string>();
+
+  /** Nodes we are currently exploring */
+  const stack = new Set<string>();
+
+  function dfs(node: string): boolean {
+    if (stack.has(node)) {
+      return true;
+    }
+
+    if (visited.has(node)) {
+      return false;
+    }
+
+    visited.add(node);
+    stack.add(node);
+
+    for (const neighbour of graph.get(node) ?? []) {
+      if (dfs(neighbour)) {
+        return true;
+      }
+    }
+
+    stack.delete(node);
+    return false;
+  }
+
+  return [...graph.keys()].some(dfs);
+};
+
+/** recursive tree traversal using a visitor callback */
+function visit(value: unknown, callback: (node: SchemaNode) => void): void {
+  if (Array.isArray(value)) {
+    value.forEach((v) => visit(v, callback));
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    const node = value as SchemaNode;
+
+    callback(node);
+
+    Object.values(node).forEach((v) => visit(v, callback));
+  }
+}
+
+/**
+ * Detect recursive schemas and give them a skip prop.
+ * This is a temporary measure to stop plan pages freezing;
+ * plans which do not render should have either custom UI
+ * or a generic JSON editor.
+ */
+export const skipRecursiveSchemas: Sanitiser = (node) => {
+  node.skip = isRecursiveSchema(node);
 };

--- a/packages/blueapi-ui/src/utils/sanitisers.ts
+++ b/packages/blueapi-ui/src/utils/sanitisers.ts
@@ -1,0 +1,48 @@
+import type { Sanitiser, SchemaNode } from "./schema";
+
+const JSON_SCHEMA_TYPES = new Set([
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "object",
+  "array",
+  "null",
+]);
+
+/** Replaces any unknown types for `string` when an enum field exists */
+export const replaceUnknownEnumTypes: Sanitiser = (node) => {
+  if (
+    Array.isArray(node.enum) &&
+    typeof node.type === "string" &&
+    !JSON_SCHEMA_TYPES.has(node.type)
+  ) {
+    node.type = "string";
+  }
+  return node;
+};
+
+export const collapseAnyOfEnumBranches: Sanitiser = (node) => {
+  if (!Array.isArray(node.anyOf)) {
+    return node;
+  }
+
+  const branches = node.anyOf;
+
+  const allEnumBranches = branches.every(
+    (branch) =>
+      typeof branch === "object" && Array.isArray((branch as SchemaNode).enum),
+  );
+
+  if (!allEnumBranches) return node;
+
+  const values = [
+    ...new Set(
+      branches.flatMap((branch) => (branch as SchemaNode).enum as unknown[]),
+    ),
+  ];
+
+  delete node.anyOf;
+  node.type = "string";
+  node.enum = values;
+};

--- a/packages/blueapi-ui/src/utils/schema.test.ts
+++ b/packages/blueapi-ui/src/utils/schema.test.ts
@@ -2,7 +2,7 @@ import type { Plan } from "@atlas/blueapi";
 import { sanitisePlan } from "./schema";
 
 describe("sanitiseSchema", () => {
-  (it("replaces unknown JSON types for string when there is an enum provided", () => {
+  it("replaces unknown JSON types for string when there is an enum provided", () => {
     const plan: Plan = {
       name: "prepare_beamline_for_robot_load",
       description: undefined,
@@ -35,96 +35,140 @@ describe("sanitiseSchema", () => {
 
     expect(schema.properties.blower.type).toBe("string");
     expect(schema.properties.cobra.type).toBe("string");
-  }),
-    it("(perhaps too conservatively) does not replace unknown types when no enum is provided", () => {
-      // unsure whether this is a realistic scenario...
+  });
 
-      const exoticType = "some.vendor.Device";
+  it("(perhaps too conservatively) does not replace unknown types when no enum is provided", () => {
+    // unsure whether this is a realistic scenario...
 
-      const plan: Plan = {
-        name: "Test plan",
-        description: "plan with exotic type",
-        schema: {
-          properties: {
-            device: {
-              title: "Device",
-              type: exoticType,
-            },
-          },
-        },
-      };
+    const exoticType = "some.vendor.Device";
 
-      const schema = sanitisePlan(plan).schema as {
+    const plan: Plan = {
+      name: "Test plan",
+      description: "plan with exotic type",
+      schema: {
         properties: {
-          device: { type: string };
-        };
-      };
+          device: {
+            title: "Device",
+            type: exoticType,
+          },
+        },
+      },
+    };
 
-      expect(schema.properties.device.type).toBe(exoticType);
-    }),
-    it("recursively sanitises all nodes", () => {
-      const typeToReplace = "bluesky.protocols.Movable";
-      const matchingNode = {
-        enum: ["robot", "stage_y"],
-        type: typeToReplace,
+    const schema = sanitisePlan(plan).schema as {
+      properties: {
+        device: { type: string };
       };
+    };
 
-      const plan = {
-        name: "my plan",
-        description: "",
-        schema: {
-          level1: {
+    expect(schema.properties.device.type).toBe(exoticType);
+  });
+
+  it("recursively sanitises all nodes", () => {
+    const typeToReplace = "bluesky.protocols.Movable";
+    const matchingNode = {
+      enum: ["robot", "stage_y"],
+      type: typeToReplace,
+    };
+
+    const plan = {
+      name: "my plan",
+      description: "",
+      schema: {
+        level1: {
+          ...matchingNode,
+          level2: {
             ...matchingNode,
-            level2: {
-              ...matchingNode,
-            },
           },
         },
-      };
+      },
+    };
 
-      // first a sanity check:
-      expect(JSON.stringify(plan)).toContain(typeToReplace);
-      // verify type is gone in sanitised schema:
-      expect(JSON.stringify(sanitisePlan(plan))).not.toContain(typeToReplace);
-    }),
-    it("collapses anyOf enum branches", () => {
-      const plan: Plan = {
-        name: "",
-        description: "",
-        schema: {
-          properties: {
-            detectors: {
-              items: {
-                anyOf: [
-                  {
-                    type: "bluesky.protocols.Readable",
-                    enum: ["cam1", "cam2"],
-                  },
-                  {
-                    type: "ophyd_async.core._protocol.AsyncReadable",
-                    enum: ["cam1", "cam3"],
-                  },
-                ],
-              },
-            },
-          },
-        },
-      };
-      const collapsed = sanitisePlan(plan).schema as {
+    // first a sanity check:
+    expect(JSON.stringify(plan)).toContain(typeToReplace);
+    // verify type is gone in sanitised schema:
+    expect(JSON.stringify(sanitisePlan(plan))).not.toContain(typeToReplace);
+  });
+
+  it("collapses anyOf enum branches", () => {
+    const plan: Plan = {
+      name: "",
+      description: "",
+      schema: {
         properties: {
           detectors: {
             items: {
-              type: string;
-              enum: string[];
-            };
+              anyOf: [
+                {
+                  type: "bluesky.protocols.Readable",
+                  enum: ["cam1", "cam2"],
+                },
+                {
+                  type: "ophyd_async.core._protocol.AsyncReadable",
+                  enum: ["cam1", "cam3"],
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const collapsed = sanitisePlan(plan).schema as {
+      properties: {
+        detectors: {
+          items: {
+            type: string;
+            enum: string[];
           };
         };
       };
+    };
 
-      expect(collapsed.properties.detectors.items.enum).toEqual([
-        "cam1",
-        "cam2",
-        "cam3",
-      ]);
-    }));
+    expect(collapsed.properties.detectors.items.enum).toEqual([
+      "cam1",
+      "cam2",
+      "cam3",
+    ]);
+  });
+
+  it("Identifies and skips recursive schemas", () => {
+    const recursivePlan: Plan = {
+      name: "Spec",
+      description: "Captures the recursive nature of spec_scan",
+      schema: {
+        $defs: {
+          A: { spec: "#/$defs/Spec" },
+          B: {
+            spec: {
+              anyOf: [
+                {
+                  $ref: "#/$defs/Spec",
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
+            C: {
+              num: {
+                title: "Num",
+                type: "integer",
+              },
+            },
+            Spec: {
+              oneOf: [
+                { $ref: "#/$defs/A" },
+                { $ref: "#/$defs/B" },
+                { $ref: "#/$defs/C" },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const sanitised = sanitisePlan(recursivePlan);
+    const schema = sanitised.schema as { skip: boolean };
+    expect(schema.skip).toBe(true);
+  });
 });

--- a/packages/blueapi-ui/src/utils/schema.test.ts
+++ b/packages/blueapi-ui/src/utils/schema.test.ts
@@ -2,7 +2,7 @@ import type { Plan } from "@atlas/blueapi";
 import { sanitisePlan } from "./schema";
 
 describe("sanitiseSchema", () => {
-  ((it("replaces unknown JSON types for string when there is an enum provided", () => {
+  (it("replaces unknown JSON types for string when there is an enum provided", () => {
     const plan: Plan = {
       name: "prepare_beamline_for_robot_load",
       description: undefined,
@@ -36,32 +36,32 @@ describe("sanitiseSchema", () => {
     expect(schema.properties.blower.type).toBe("string");
     expect(schema.properties.cobra.type).toBe("string");
   }),
-  it("(perhaps too conservatively) does not replace unknown types when no enum is provided", () => {
-    // unsure whether this is a realistic scenario...
+    it("(perhaps too conservatively) does not replace unknown types when no enum is provided", () => {
+      // unsure whether this is a realistic scenario...
 
-    const exoticType = "some.vendor.Device";
+      const exoticType = "some.vendor.Device";
 
-    const plan: Plan = {
-      name: "Test plan",
-      description: "plan with exotic type",
-      schema: {
-        properties: {
-          device: {
-            title: "Device",
-            type: exoticType,
+      const plan: Plan = {
+        name: "Test plan",
+        description: "plan with exotic type",
+        schema: {
+          properties: {
+            device: {
+              title: "Device",
+              type: exoticType,
+            },
           },
         },
-      },
-    };
-
-    const schema = sanitisePlan(plan).schema as {
-      properties: {
-        device: { type: string };
       };
-    };
 
-    expect(schema.properties.device.type).toBe(exoticType);
-  })),
+      const schema = sanitisePlan(plan).schema as {
+        properties: {
+          device: { type: string };
+        };
+      };
+
+      expect(schema.properties.device.type).toBe(exoticType);
+    }),
     it("recursively sanitises all nodes", () => {
       const typeToReplace = "bluesky.protocols.Movable";
       const matchingNode = {
@@ -86,5 +86,45 @@ describe("sanitiseSchema", () => {
       expect(JSON.stringify(plan)).toContain(typeToReplace);
       // verify type is gone in sanitised schema:
       expect(JSON.stringify(sanitisePlan(plan))).not.toContain(typeToReplace);
+    }),
+    it("collapses anyOf enum branches", () => {
+      const plan: Plan = {
+        name: "",
+        description: "",
+        schema: {
+          properties: {
+            detectors: {
+              items: {
+                anyOf: [
+                  {
+                    type: "bluesky.protocols.Readable",
+                    enum: ["cam1", "cam2"],
+                  },
+                  {
+                    type: "ophyd_async.core._protocol.AsyncReadable",
+                    enum: ["cam1", "cam3"],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      const collapsed = sanitisePlan(plan).schema as {
+        properties: {
+          detectors: {
+            items: {
+              type: string;
+              enum: string[];
+            };
+          };
+        };
+      };
+
+      expect(collapsed.properties.detectors.items.enum).toEqual([
+        "cam1",
+        "cam2",
+        "cam3",
+      ]);
     }));
 });

--- a/packages/blueapi-ui/src/utils/schema.test.ts
+++ b/packages/blueapi-ui/src/utils/schema.test.ts
@@ -1,0 +1,90 @@
+import type { Plan } from "@atlas/blueapi";
+import { sanitisePlan } from "./schema";
+
+describe("sanitiseSchema", () => {
+  ((it("replaces unknown JSON types for string when there is an enum provided", () => {
+    const plan: Plan = {
+      name: "prepare_beamline_for_robot_load",
+      description: undefined,
+      schema: {
+        additionalProperties: false,
+        properties: {
+          blower: {
+            enum: ["blower_z"],
+            title: "Blower",
+            type: "dodal.devices.beamlines.i15_1.blower.Blower",
+          },
+          cobra: {
+            enum: ["cobra"],
+            title: "Cobra",
+            type: "dodal.devices.beamlines.i15_1.cobra.Cobra",
+          },
+        },
+        title: "prepare_beamline_for_robot_load",
+        type: "object",
+      },
+    };
+
+    const sanitised = sanitisePlan(plan);
+    const schema = sanitised.schema as {
+      properties: {
+        blower: { type: string };
+        cobra: { type: string };
+      };
+    };
+
+    expect(schema.properties.blower.type).toBe("string");
+    expect(schema.properties.cobra.type).toBe("string");
+  }),
+  it("(perhaps too conservatively) does not replace unknown types when no enum is provided", () => {
+    // unsure whether this is a realistic scenario...
+
+    const exoticType = "some.vendor.Device";
+
+    const plan: Plan = {
+      name: "Test plan",
+      description: "plan with exotic type",
+      schema: {
+        properties: {
+          device: {
+            title: "Device",
+            type: exoticType,
+          },
+        },
+      },
+    };
+
+    const schema = sanitisePlan(plan).schema as {
+      properties: {
+        device: { type: string };
+      };
+    };
+
+    expect(schema.properties.device.type).toBe(exoticType);
+  })),
+    it("recursively sanitises all nodes", () => {
+      const typeToReplace = "bluesky.protocols.Movable";
+      const matchingNode = {
+        enum: ["robot", "stage_y"],
+        type: typeToReplace,
+      };
+
+      const plan = {
+        name: "my plan",
+        description: "",
+        schema: {
+          level1: {
+            ...matchingNode,
+            level2: {
+              ...matchingNode,
+            },
+          },
+        },
+      };
+
+      // first a sanity check:
+      expect(JSON.stringify(plan)).toContain(typeToReplace);
+      // verify type is gone in sanitised schema:
+      expect(JSON.stringify(sanitisePlan(plan))).not.toContain(typeToReplace);
+    }));
+});

--- a/packages/blueapi-ui/src/utils/schema.ts
+++ b/packages/blueapi-ui/src/utils/schema.ts
@@ -2,6 +2,7 @@ import type { Plan } from "@atlas/blueapi";
 import {
   collapseAnyOfEnumBranches,
   replaceUnknownEnumTypes,
+  skipRecursiveSchemas,
 } from "./sanitisers";
 
 export type SchemaNode = Record<string, unknown>;
@@ -10,6 +11,7 @@ export type SchemaNode = Record<string, unknown>;
 export type Sanitiser = (node: SchemaNode) => void;
 
 const SANITISERS: Sanitiser[] = [
+  skipRecursiveSchemas,
   collapseAnyOfEnumBranches,
   replaceUnknownEnumTypes,
 ];

--- a/packages/blueapi-ui/src/utils/schema.ts
+++ b/packages/blueapi-ui/src/utils/schema.ts
@@ -1,45 +1,32 @@
 import type { Plan } from "@atlas/blueapi";
+import {
+  collapseAnyOfEnumBranches,
+  replaceUnknownEnumTypes,
+} from "./sanitisers";
 
-const JSON_SCHEMA_TYPES = new Set([
-  "string",
-  "number",
-  "integer",
-  "boolean",
-  "object",
-  "array",
-  "null",
-]);
+export type SchemaNode = Record<string, unknown>;
 
-/** Replaces any unknown types for `string` when an enum field exists */
-function replaceUnknownTypes(
-  node: Record<string, unknown>,
-): Record<string, unknown> {
-  if (
-    node.enum &&
-    typeof node.type === "string" &&
-    !JSON_SCHEMA_TYPES.has(node.type)
-  ) {
-    node.type = "string";
-  }
+/** Mutating sanitising operation */
+export type Sanitiser = (node: SchemaNode) => void;
 
-  return node;
-}
+const SANITISERS: Sanitiser[] = [
+  collapseAnyOfEnumBranches,
+  replaceUnknownEnumTypes,
+];
 
-function sanitiseSchemaNode(node: unknown): unknown {
+function sanitiseNode(node: unknown): unknown {
   if (Array.isArray(node)) {
-    return node.map(sanitiseSchemaNode);
+    return node.map(sanitiseNode);
   }
 
   if (node && typeof node === "object") {
-    const result: Record<string, unknown> = {};
+    const record = Object.fromEntries(
+      Object.entries(node).map(([key, value]) => [key, sanitiseNode(value)]),
+    );
 
-    for (const [key, value] of Object.entries(node)) {
-      result[key] = sanitiseSchemaNode(value);
-    }
+    SANITISERS.forEach((sanitiser) => sanitiser(record));
 
-    const validTypes = replaceUnknownTypes(result);
-
-    return validTypes;
+    return record;
   }
 
   return node;
@@ -48,6 +35,6 @@ function sanitiseSchemaNode(node: unknown): unknown {
 export function sanitisePlan(plan: Plan): Plan {
   return {
     ...plan,
-    schema: sanitiseSchemaNode(plan.schema) as object,
+    schema: sanitiseNode(plan.schema) as object,
   };
 }

--- a/packages/blueapi-ui/src/utils/schema.ts
+++ b/packages/blueapi-ui/src/utils/schema.ts
@@ -1,25 +1,53 @@
-const shouldJustBeStrings = [
-  "bluesky.protocols.Readable",
-  "bluesky.protocols.Movable",
-];
+import type { Plan } from "@atlas/blueapi";
 
-const sanitizeSchema = (schema: object): object => {
-  const entries = Object.entries(schema);
+const JSON_SCHEMA_TYPES = new Set([
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "object",
+  "array",
+  "null",
+]);
 
-  const processed = entries.map(([key, value]) => {
-    if (key == "type" && shouldJustBeStrings.includes(value)) {
-      return [key, "string"];
-    } else if (
-      typeof value === "object" &&
-      !Array.isArray(value) &&
-      value !== null
-    ) {
-      return [key, sanitizeSchema(value)];
-    } else {
-      return [key, value];
+/** Replaces any unknown types for `string` when an enum field exists */
+function replaceUnknownTypes(
+  node: Record<string, unknown>,
+): Record<string, unknown> {
+  if (
+    node.enum &&
+    typeof node.type === "string" &&
+    !JSON_SCHEMA_TYPES.has(node.type)
+  ) {
+    node.type = "string";
+  }
+
+  return node;
+}
+
+function sanitiseSchemaNode(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(sanitiseSchemaNode);
+  }
+
+  if (node && typeof node === "object") {
+    const result: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(node)) {
+      result[key] = sanitiseSchemaNode(value);
     }
-  });
-  return Object.fromEntries(processed);
-};
 
-export default sanitizeSchema;
+    const validTypes = replaceUnknownTypes(result);
+
+    return validTypes;
+  }
+
+  return node;
+}
+
+export function sanitisePlan(plan: Plan): Plan {
+  return {
+    ...plan,
+    schema: sanitiseSchemaNode(plan.schema) as object,
+  };
+}


### PR DESCRIPTION
Replaces enum ophyd types with 'string', and collapses enum anyOf branches.
Closes #64 once recursive plans (e.g. spec_scan) are handled.