### PR TITLE
I15-1: Add webcam streams to robot page

### DIFF
--- a/apps/i15-1/README.md
+++ b/apps/i15-1/README.md
@@ -70,3 +70,10 @@ export function QueryData() {
   return data?.instrumentSession?.state || [];
 }
 ```
+
+## Viewing Camera Streams on Firefox
+
+1. Ensure you are on the beamline network
+1. Type `about:config` in the address bar and press the return key.
+1. Click `Accpt the Risk and Continue` on the warning screen.
+1. Search for the following preference `security.mixed_content.upgrade_display_content.image` and change the value to `false`.

--- a/apps/i15-1/src/components/Webcam.tsx
+++ b/apps/i15-1/src/components/Webcam.tsx
@@ -14,7 +14,7 @@ export function WebcamStreamFromUrl(props: WebcamStreamProps) {
 
   return (
     <Box sx={{ ml: 5 }}>
-      {" "}
+      {props.label}
       <Webcam name={props.label} url={props.sourceUrl} position={relativePos} />
     </Box>
   );

--- a/apps/i15-1/src/components/Webcam.tsx
+++ b/apps/i15-1/src/components/Webcam.tsx
@@ -1,0 +1,46 @@
+import { Webcam, newRelativePosition } from "@diamondlightsource/cs-web-lib";
+import { Box } from "@mui/material";
+import { useParsedPvConnection, type ParsePvProps } from "@atlas/pvws-config";
+
+type WebcamStreamProps = {
+  label: string;
+  sourceUrl?: string;
+  sourcePv?: string;
+  size?: string;
+};
+
+export function WebcamStreamFromUrl(props: WebcamStreamProps) {
+  const relativePos = newRelativePosition("0", "0", props.size, props.size);
+
+  return (
+    <Box sx={{ ml: 5 }}>
+      {" "}
+      <Webcam name={props.label} url={props.sourceUrl} position={relativePos} />
+    </Box>
+  );
+}
+
+export function WebcamStreamFromPv(props: WebcamStreamProps) {
+  let sourceUrl = "";
+  const pvProps: ParsePvProps = {
+    label: props.label,
+    pv: props.sourcePv ? props.sourcePv : "undefined",
+    parseByeArr: true,
+  };
+  const parsedPv = useParsedPvConnection(pvProps);
+  if (parsedPv === "undefined") {
+    console.log(`pv source for webcam (${props.sourcePv}) was undefined`);
+  } else if (parsedPv === "not connected") {
+    console.log(`pv source for webcam (${props.sourcePv}) was not connected`);
+  } else {
+    sourceUrl = parsedPv;
+  }
+
+  return (
+    <WebcamStreamFromUrl
+      label={props.label}
+      sourceUrl={sourceUrl}
+      size={props.size}
+    />
+  );
+}

--- a/apps/i15-1/src/components/Webcam.tsx
+++ b/apps/i15-1/src/components/Webcam.tsx
@@ -5,8 +5,8 @@ import { useParsedPvConnection, type ParsePvProps } from "@atlas/pvws-config";
 type WebcamStreamProps = {
   label: string;
   sourceUrl?: string;
-  sourcePv?: string;
-  size?: string;
+  sourcePv?: string; // PV from which a sourceUrl is fetched
+  size?: string; // Width and height of the webcam widget in pixels
 };
 
 export function WebcamStreamFromUrl(props: WebcamStreamProps) {

--- a/apps/i15-1/src/routes/Robot.tsx
+++ b/apps/i15-1/src/routes/Robot.tsx
@@ -3,7 +3,11 @@ import { Box, Typography, Stack, useTheme } from "@mui/material";
 import { useState } from "react";
 import { NumberInput } from "../components/NumberInput";
 import { RunPlanButton } from "@atlas/blueapi-ui";
-import { ReadOnlyPv } from "@atlas/pvws-config";
+import {
+  ReadOnlyPv,
+  useParsedPvConnection,
+  type ParsePvProps,
+} from "@atlas/pvws-config";
 import { StatusCard } from "../components/StatusCard";
 
 import { Webcam, newRelativePosition } from "@diamondlightsource/cs-web-lib";
@@ -117,14 +121,16 @@ function WebCams() {
   const theme = useTheme();
   const relativePos = newRelativePosition("0", "0", "250", "250");
 
+  const jweb1PvProps: ParsePvProps = {
+    label: "jweb1",
+    pv: "BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV",
+  };
+  const jweb1Url = useParsedPvConnection(jweb1PvProps);
+
   return (
     <Box sx={{ ml: 5 }}>
       {" "}
-      <Webcam
-        name="Robot"
-        url="http://i15-k8s-serv-01.diamond.ac.uk:8094/JWEB1.mjpg.mjpg"
-        position={relativePos}
-      />
+      <Webcam name="Robot" url={jweb1Url} position={relativePos} />
     </Box>
   );
 }

--- a/apps/i15-1/src/routes/Robot.tsx
+++ b/apps/i15-1/src/routes/Robot.tsx
@@ -5,7 +5,7 @@ import { NumberInput } from "../components/NumberInput";
 import { RunPlanButton } from "@atlas/blueapi-ui";
 import { ReadOnlyPv } from "@atlas/pvws-config";
 import { StatusCard } from "../components/StatusCard";
-import { WebcamStreamFromPv, WebcamStreamFromUrl } from "../components/Webcam";
+import { WebcamStreamFromPv } from "../components/Webcam";
 
 type RobotSampleFormData = {
   puck: number;
@@ -132,9 +132,9 @@ function Robot() {
             sourcePv="ca://BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV"
             size="250"
           />
-          <WebcamStreamFromUrl
+          <WebcamStreamFromPv
             label="JCAM2"
-            sourceUrl="http://i15-k8s-serv-01.diamond.ac.uk:8081/JCAM2.mjpg.mjpg"
+            sourcePv="ca://BL15J-DI-CAM-02:MJPG:MJPG_URL_RBV"
             size="250"
           />
           <RobotControl />

--- a/apps/i15-1/src/routes/Robot.tsx
+++ b/apps/i15-1/src/routes/Robot.tsx
@@ -3,15 +3,9 @@ import { Box, Typography, Stack, useTheme } from "@mui/material";
 import { useState } from "react";
 import { NumberInput } from "../components/NumberInput";
 import { RunPlanButton } from "@atlas/blueapi-ui";
-import {
-  ReadOnlyPv,
-  useParsedPvConnection,
-  type ParsePvProps,
-} from "@atlas/pvws-config";
+import { ReadOnlyPv } from "@atlas/pvws-config";
 import { StatusCard } from "../components/StatusCard";
-
-import { Webcam, newRelativePosition } from "@diamondlightsource/cs-web-lib";
-import { Web } from "@mui/icons-material";
+import { WebcamStreamFromPv, WebcamStreamFromUrl } from "../components/Webcam";
 
 type RobotSampleFormData = {
   puck: number;
@@ -118,26 +112,6 @@ function RobotControl() {
   );
 }
 
-function WebCamStream({
-  label,
-  sourceUrl,
-  pv,
-}: {
-  label: string;
-  sourceUrl: string;
-  pv: string;
-}) {
-  const relativePos = newRelativePosition("0", "0", "250", "250");
-
-  return (
-    <Box sx={{ ml: 5 }}>
-      {" "}
-      <ReadOnlyPv label={label} pv={pv} />
-      <Webcam name={label} url={sourceUrl} position={relativePos} />
-    </Box>
-  );
-}
-
 function Robot() {
   return (
     <Box
@@ -153,15 +127,15 @@ function Robot() {
       <Stack direction={"column"} spacing={3} alignItems={"left"}>
         <StatusSidebar />
         <Stack direction={"row"} spacing={3} alignItems={"left"}>
-          <WebCamStream
+          <WebcamStreamFromPv
             label="JWEB1"
-            sourceUrl="http://i15-k8s-serv-01.diamond.ac.uk:8094/JWEB1.mjpg.mjpg"
-            pv="ca://BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV"
+            sourcePv="ca://BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV"
+            size="250"
           />
-          <WebCamStream
+          <WebcamStreamFromUrl
             label="JCAM2"
             sourceUrl="http://i15-k8s-serv-01.diamond.ac.uk:8081/JCAM2.mjpg.mjpg"
-            pv="ca://BL15J-DI-CAM-02:MJPG:MJPG_URL_RBV"
+            size="250"
           />
           <RobotControl />
         </Stack>

--- a/apps/i15-1/src/routes/Robot.tsx
+++ b/apps/i15-1/src/routes/Robot.tsx
@@ -11,6 +11,7 @@ import {
 import { StatusCard } from "../components/StatusCard";
 
 import { Webcam, newRelativePosition } from "@diamondlightsource/cs-web-lib";
+import { Web } from "@mui/icons-material";
 
 type RobotSampleFormData = {
   puck: number;
@@ -117,16 +118,22 @@ function RobotControl() {
   );
 }
 
-function WebCams() {
+function WebCamStream({
+  label,
+  sourceUrl,
+  pv,
+}: {
+  label: string;
+  sourceUrl: string;
+  pv: string;
+}) {
   const relativePos = newRelativePosition("0", "0", "250", "250");
-
-  const jweb1Url = "http://i15-k8s-serv-01.diamond.ac.uk:8094/JWEB1.mjpg.mjpg";
 
   return (
     <Box sx={{ ml: 5 }}>
       {" "}
-      <ReadOnlyPv label="JWEB1" pv="ca://BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV" />
-      <Webcam name="Robot" url={jweb1Url} position={relativePos} />
+      <ReadOnlyPv label={label} pv={pv} />
+      <Webcam name={label} url={sourceUrl} position={relativePos} />
     </Box>
   );
 }
@@ -146,7 +153,16 @@ function Robot() {
       <Stack direction={"column"} spacing={3} alignItems={"left"}>
         <StatusSidebar />
         <Stack direction={"row"} spacing={3} alignItems={"left"}>
-          <WebCams />
+          <WebCamStream
+            label="JWEB1"
+            sourceUrl="http://i15-k8s-serv-01.diamond.ac.uk:8094/JWEB1.mjpg.mjpg"
+            pv="ca://BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV"
+          />
+          <WebCamStream
+            label="JCAM2"
+            sourceUrl="http://i15-k8s-serv-01.diamond.ac.uk:8081/JCAM2.mjpg.mjpg"
+            pv="ca://BL15J-DI-CAM-02:MJPG:MJPG_URL_RBV"
+          />
           <RobotControl />
         </Stack>
       </Stack>

--- a/apps/i15-1/src/routes/Robot.tsx
+++ b/apps/i15-1/src/routes/Robot.tsx
@@ -125,7 +125,7 @@ function WebCams() {
   return (
     <Box sx={{ ml: 5 }}>
       {" "}
-      <ReadOnlyPv label="JWEB1" pv="BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV" />
+      <ReadOnlyPv label="JWEB1" pv="ca://BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV" />
       <Webcam name="Robot" url={jweb1Url} position={relativePos} />
     </Box>
   );

--- a/apps/i15-1/src/routes/Robot.tsx
+++ b/apps/i15-1/src/routes/Robot.tsx
@@ -112,6 +112,10 @@ function RobotControl() {
   );
 }
 
+// TODO: Webcams currently not visible unless streams are not automatically
+// upgraded to https (and not available outside the beamline network). Stream
+// serving needs to be updated when available.
+// https://github.com/DiamondLightSource/atlas/issues/90
 function Robot() {
   return (
     <Box

--- a/apps/i15-1/src/routes/Robot.tsx
+++ b/apps/i15-1/src/routes/Robot.tsx
@@ -6,6 +6,8 @@ import { RunPlanButton } from "@atlas/blueapi-ui";
 import { ReadOnlyPv } from "@atlas/pvws-config";
 import { StatusCard } from "../components/StatusCard";
 
+import { Webcam, newRelativePosition } from "@diamondlightsource/cs-web-lib";
+
 type RobotSampleFormData = {
   puck: number;
   position: number;
@@ -15,18 +17,7 @@ function StatusSidebar() {
   const theme = useTheme();
   return (
     <Box sx={{ ml: 5 }}>
-      <Stack direction={"column"} spacing={2}>
-        <StatusCard
-          title="Currently loaded"
-          bgColor={theme.palette.info.light}
-          cardColor={theme.palette.primary.main}
-        >
-          <ReadOnlyPv label="Puck" pv="ca://BL15J-EA-LOC-01:PUCK:INDEX" />
-          <ReadOnlyPv
-            label="Sample Pin"
-            pv="ca://BL15J-EA-LOC-01:SAMPLE:INDEX"
-          />
-        </StatusCard>
+      <Stack direction={"row"} spacing={2}>
         <StatusCard
           title="Ring status"
           bgColor={theme.palette.success.light}
@@ -45,7 +36,95 @@ function StatusSidebar() {
             units="GeV"
           />
         </StatusCard>
+        <StatusCard
+          title="EH3 Safety"
+          bgColor={theme.palette.success.light}
+          cardColor={theme.palette.primary.main}
+        >
+          <ReadOnlyPv label="Hutch Enabled" pv="ca://BL15I-PS-IOC-02:M14:LOP" />
+        </StatusCard>
+        <StatusCard
+          title="Currently loaded"
+          bgColor={theme.palette.info.light}
+          cardColor={theme.palette.primary.main}
+        >
+          <ReadOnlyPv label="Puck" pv="ca://BL15J-EA-LOC-01:PUCK:INDEX" />
+          <ReadOnlyPv
+            label="Sample Pin"
+            pv="ca://BL15J-EA-LOC-01:SAMPLE:INDEX"
+          />
+        </StatusCard>
       </Stack>
+    </Box>
+  );
+}
+
+function RobotControl() {
+  const { instrumentSession } = useInstrumentSession();
+  const [formData, setFormData] = useState<RobotSampleFormData>({
+    puck: 1,
+    position: 1,
+  });
+  const theme = useTheme();
+  return (
+    <Box
+      sx={{
+        padding: 5,
+        borderRadius: 1,
+        border: "1px solid",
+        borderColor: theme.palette.primary.main,
+      }}
+    >
+      <Stack direction={"column"} spacing={3} alignItems={"center"}>
+        <Typography component="h1" variant="h5">
+          Robot Control
+        </Typography>
+        <Stack direction={"row"} spacing={3} alignItems={"center"}>
+          <NumberInput
+            label="Puck"
+            numberMode="natural"
+            defaultValue={formData["puck"]}
+            onCommit={(parsedValue) => {
+              setFormData({ ...formData, ["puck"]: parsedValue });
+            }}
+          />
+          <NumberInput
+            label="Position"
+            numberMode="natural"
+            defaultValue={formData["position"]}
+            onCommit={(parsedValue) => {
+              setFormData({ ...formData, ["position"]: parsedValue });
+            }}
+          />
+        </Stack>
+        <RunPlanButton
+          name="robot_load"
+          params={formData}
+          instrumentSession={instrumentSession}
+          buttonText="Load Sample"
+        />
+        <RunPlanButton
+          name="robot_unload"
+          instrumentSession={instrumentSession}
+          buttonText="Unload Sample"
+        />
+      </Stack>
+    </Box>
+  );
+}
+
+function WebCams() {
+  const theme = useTheme();
+  const relativePos = newRelativePosition("0", "0", "250", "250");
+
+  return (
+    <Box sx={{ ml: 5 }}>
+      {" "}
+      <Webcam
+        name="Robot"
+        url="http://i15-k8s-serv-01.diamond.ac.uk:8094/JWEB1.mjpg.mjpg"
+        position={relativePos}
+      />
     </Box>
   );
 }
@@ -62,56 +141,19 @@ function Robot() {
       // component={"section"}
       sx={{
         display: "flex",
-        justifyContent: "center",
+        justifyContent: "left",
         mt: 3,
         mr: 5,
         ml: 5,
       }}
     >
-      <Box
-        sx={{
-          padding: 5,
-          borderRadius: 1,
-          border: "1px solid",
-          borderColor: theme.palette.primary.main,
-        }}
-      >
-        <Stack direction={"column"} spacing={3} alignItems={"center"}>
-          <Typography component="h1" variant="h5">
-            Sample Position
-          </Typography>
-          <Stack direction={"row"} spacing={3} alignItems={"center"}>
-            <NumberInput
-              label="Puck"
-              numberMode="natural"
-              defaultValue={formData["puck"]}
-              onCommit={(parsedValue) => {
-                setFormData({ ...formData, ["puck"]: parsedValue });
-              }}
-            />
-            <NumberInput
-              label="Position"
-              numberMode="natural"
-              defaultValue={formData["position"]}
-              onCommit={(parsedValue) => {
-                setFormData({ ...formData, ["position"]: parsedValue });
-              }}
-            />
-          </Stack>
-          <RunPlanButton
-            name="robot_load"
-            params={formData}
-            instrumentSession={instrumentSession}
-            buttonText="Load Sample"
-          />
-          <RunPlanButton
-            name="robot_unload"
-            instrumentSession={instrumentSession}
-            buttonText="Unload Sample"
-          />
+      <Stack direction={"column"} spacing={3} alignItems={"left"}>
+        <StatusSidebar />
+        <Stack direction={"row"} spacing={3} alignItems={"left"}>
+          <WebCams />
+          <RobotControl />
         </Stack>
-      </Box>
-      <StatusSidebar />
+      </Stack>
     </Box>
   );
 }

--- a/apps/i15-1/src/routes/Robot.tsx
+++ b/apps/i15-1/src/routes/Robot.tsx
@@ -118,30 +118,20 @@ function RobotControl() {
 }
 
 function WebCams() {
-  const theme = useTheme();
   const relativePos = newRelativePosition("0", "0", "250", "250");
 
-  const jweb1PvProps: ParsePvProps = {
-    label: "jweb1",
-    pv: "BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV",
-  };
-  const jweb1Url = useParsedPvConnection(jweb1PvProps);
+  const jweb1Url = "http://i15-k8s-serv-01.diamond.ac.uk:8094/JWEB1.mjpg.mjpg";
 
   return (
     <Box sx={{ ml: 5 }}>
       {" "}
+      <ReadOnlyPv label="JWEB1" pv="BL15J-DI-WEB-01:MJPG:MJPG_URL_RBV" />
       <Webcam name="Robot" url={jweb1Url} position={relativePos} />
     </Box>
   );
 }
 
 function Robot() {
-  const { instrumentSession } = useInstrumentSession();
-  const [formData, setFormData] = useState<RobotSampleFormData>({
-    puck: 1,
-    position: 1,
-  });
-  const theme = useTheme();
   return (
     <Box
       // component={"section"}

--- a/packages/pvws-config/src/readPv.test.ts
+++ b/packages/pvws-config/src/readPv.test.ts
@@ -1,4 +1,4 @@
-import { parseNumericPV, parseStringPv } from "./readPv";
+import { parseNumericPV, parseStringPv, parseByteArrPV } from "./readPv";
 import { type DType } from "@diamondlightsource/cs-web-lib";
 
 describe("Test Pv utils", () => {
@@ -20,5 +20,10 @@ describe("Test Pv utils", () => {
     expect(parseStringPv(newDType)).toEqual("Open");
     expect(parseStringPv(10)).toEqual("10");
     expect(parseStringPv("Close")).toEqual("Close");
+  });
+
+  it("parses byte array values to a string", () => {
+    expect(parseByteArrPV("not connected")).toEqual("not connected");
+    expect(parseByteArrPV(undefined)).toEqual("undefined");
   });
 });

--- a/packages/pvws-config/src/readPv.ts
+++ b/packages/pvws-config/src/readPv.ts
@@ -16,6 +16,9 @@ export function ReadPvRawValue({
   return rawValue;
 }
 
+// TODO: Simplify PV parsing functions with newly exposed cs-web-lib utils
+// https://github.com/DiamondLightSource/atlas/issues/93
+
 export function parseStringPv(value: RawValue | string | number): string {
   let displayValue: string;
   if (value != "not connected" && value != undefined) {

--- a/packages/pvws-config/src/readPv.ts
+++ b/packages/pvws-config/src/readPv.ts
@@ -74,3 +74,27 @@ export function parseNumericPV(
   }
   return displayValue;
 }
+
+export function parseByteArrPV(value: RawValue | string | number): string {
+  let displayValue: string;
+  if (value != "not connected" && value != undefined) {
+    const arrValue = (value as DType).value.arrayValue;
+    if (!arrValue) {
+      displayValue = "undefined";
+    } else {
+      let result = "";
+      for (let i = 0; i < arrValue.length; i++) {
+        if (Number(arrValue[i]) === 0) {
+          break;
+        }
+        result += String.fromCharCode(Number(arrValue[i]));
+      }
+      displayValue = result;
+    }
+  } else if (value == "not connected") {
+    displayValue = "not connected";
+  } else {
+    displayValue = "undefined";
+  }
+  return displayValue;
+}

--- a/packages/pvws-config/src/types.ts
+++ b/packages/pvws-config/src/types.ts
@@ -3,9 +3,6 @@ import { type DType } from "@diamondlightsource/cs-web-lib";
 type NotConnected = "not connected";
 
 export type RawValue = DType | undefined | NotConnected;
-// NOTE - ACHTUNG! DTYPE not exported anymore in newer versions
-// Problem is that useConnection returns latest value as Dtype so we need it
-// waiting for an answer on this, in the meantime sticking to 0.9.5
 
 export type PvDescription = {
   label: string;
@@ -14,6 +11,7 @@ export type PvDescription = {
 
 export type ParsePvProps = PvDescription & {
   parseNumeric?: boolean;
+  parseByeArr?: boolean;
   decimals?: number;
   scaleFactor?: number;
   units?: string;

--- a/packages/pvws-config/src/useParsedPvConnection.ts
+++ b/packages/pvws-config/src/useParsedPvConnection.ts
@@ -1,9 +1,15 @@
-import { parseNumericPV, parseStringPv, ReadPvRawValue } from "./readPv";
+import {
+  parseNumericPV,
+  parseByteArrPV,
+  parseStringPv,
+  ReadPvRawValue,
+} from "./readPv";
 import type { ParsePvProps } from "./types";
 
 export function useParsedPvConnection(props: ParsePvProps): string {
   const rawValue = ReadPvRawValue({ label: props.label, pv: props.pv });
   const numericPv = props.parseNumeric ? props.parseNumeric : false;
+  const byeArrPv = props.parseByeArr ? props.parseByeArr : false;
   let returnValue;
   if (rawValue === "not connected") {
     returnValue = "not connected";
@@ -13,6 +19,8 @@ export function useParsedPvConnection(props: ParsePvProps): string {
   } else {
     if (numericPv) {
       returnValue = parseNumericPV(rawValue, props.decimals, props.scaleFactor);
+    } else if (byeArrPv) {
+      returnValue = parseByteArrPV(rawValue);
     } else {
       returnValue = parseStringPv(rawValue);
     }


### PR DESCRIPTION
Fixes #75 

Adds webcam streams to robot page.

Currently webcam streams are only available when UI has been deployed on the beamline (camera stream source is taken from a PV, which is not mocked), and with a change to default firefox settings (go to `about:config`, and set `security.mixed_content.upgrade_display_content.image` to false).

Deploy these updates by pointing to the `ea/test_ui_changes` branch for `i15-1-ui`