### PR TITLE
Add option to use local BlueAPI

### DIFF
--- a/apps/i15-1/README.md
+++ b/apps/i15-1/README.md
@@ -9,8 +9,8 @@ To run this locally:
 1.  Start the devcontainer in VSCode
 1.  To make sure you have the most up-to-date environment either run `pnpm install` in the container or rebuild the container (via the Ctrl+Shift+P menu in VSCode)
 1.  In a terminal in this devcontainer run either:
-    - `VITE_USE_LOCAL=true turbo dev --filter @atlas/i15-1` if running a local queue server on http://127.0.0.1:8001, **OR**
-    - `turbo dev --filter @atlas/i15-1` to use mocked backends
+    - If wanting to test against local services (see [here](https://github.com/DiamondLightSource/daq-queuing-service#daq_queuing_service) for spinning up local serives) run using `VITE_USE_LOCAL=true turbo dev --filter @atlas/i15-1`, **OR**
+    - If you want to test against mocked behaviour run `turbo dev --filter @atlas/i15-1`
 1.  Navigate to http://localhost:5173/
 
 ## Updating Supergraph Schema Types

--- a/apps/i15-1/README.md
+++ b/apps/i15-1/README.md
@@ -9,7 +9,7 @@ To run this locally:
 1.  Start the devcontainer in VSCode
 1.  To make sure you have the most up-to-date environment either run `pnpm install` in the container or rebuild the container (via the Ctrl+Shift+P menu in VSCode)
 1.  In a terminal in this devcontainer run either:
-    - `VITE_QUEUE_MODE=local turbo dev --filter @atlas/i15-1` if running a local queue server on http://127.0.0.1:8001, **OR**
+    - `VITE_USE_LOCAL=true turbo dev --filter @atlas/i15-1` if running a local queue server on http://127.0.0.1:8001, **OR**
     - `turbo dev --filter @atlas/i15-1` to use mocked backends
 1.  Navigate to http://localhost:5173/
 

--- a/apps/i15-1/src/mocks/handlers.ts
+++ b/apps/i15-1/src/mocks/handlers.ts
@@ -2,7 +2,6 @@ import { http, HttpResponse, ws, passthrough } from "msw";
 import plansResponse from "./plans-response.json";
 
 const USE_LOCAL = import.meta.env.VITE_USE_LOCAL === "true";
-console.log(USE_LOCAL);
 
 const fakeTaskId = "7304e8e0-81c6-4978-9a9d-9046ab79ce3c";
 const workerStatus = { status: "IDLE", duration: 0 };

--- a/apps/i15-1/src/mocks/handlers.ts
+++ b/apps/i15-1/src/mocks/handlers.ts
@@ -1,5 +1,8 @@
-import { http, HttpResponse, ws } from "msw";
+import { http, HttpResponse, ws, passthrough } from "msw";
 import plansResponse from "./plans-response.json";
+
+const USE_LOCAL = import.meta.env.VITE_USE_LOCAL === "true";
+console.log(USE_LOCAL);
 
 const fakeTaskId = "7304e8e0-81c6-4978-9a9d-9046ab79ce3c";
 const workerStatus = { status: "IDLE", duration: 0 };
@@ -13,7 +16,7 @@ const fakeExperiments = {
             node: {
               name: "Test experiment",
               sample: {
-                name: "Test_sample",
+                name: "Test_8_1",
                 data: {
                   density: 56,
                   capillary: "bs1.5",
@@ -37,7 +40,7 @@ const fakeExperiments = {
             node: {
               name: "Test experiment 2",
               sample: {
-                name: "Test_sample 2",
+                name: "Test_8_2",
                 data: {
                   density: 56,
                   capillary: "bs1.5",
@@ -169,6 +172,8 @@ const fakeQueue = [
 ];
 
 export const handlers = [
+  ...(USE_LOCAL ? [http.all("/api/blueapi/*", () => passthrough())] : []),
+
   http.put("/api/blueapi/worker/task", () => {
     workerStatus.status = "RUNNING";
     return HttpResponse.json({

--- a/apps/i15-1/src/queue/queueService.ts
+++ b/apps/i15-1/src/queue/queueService.ts
@@ -12,9 +12,10 @@ import { client } from "../../generated/queue/client.gen";
 import type { QueuedTasks } from "./tasks";
 
 // This should be tidied up in https://github.com/DiamondLightSource/atlas/issues/59
-const QUEUE_MODE = import.meta.env.VITE_QUEUE_MODE;
-const QUEUE_SOCKET: string =
-  QUEUE_MODE === "local" ? "http://127.0.0.1:8001" : "/api/daq-queue";
+const USE_LOCAL = import.meta.env.VITE_USE_LOCAL === "true";
+const QUEUE_SOCKET: string = USE_LOCAL
+  ? "http://127.0.0.1:8001"
+  : "/api/daq-queue";
 
 client.setConfig({ baseUrl: QUEUE_SOCKET });
 

--- a/apps/i15-1/src/queue/queueService.ts
+++ b/apps/i15-1/src/queue/queueService.ts
@@ -12,6 +12,8 @@ import { client } from "../../generated/queue/client.gen";
 import type { QueuedTasks } from "./tasks";
 
 // This should be tidied up in https://github.com/DiamondLightSource/atlas/issues/59
+// Ideally we would use a vite proxy for it (like BlueAPI) but this doesn't play nice
+// with the websockets needed for `events`
 const USE_LOCAL = import.meta.env.VITE_USE_LOCAL === "true";
 const QUEUE_SOCKET: string = USE_LOCAL
   ? "http://127.0.0.1:8001"

--- a/apps/i15-1/vite.config.ts
+++ b/apps/i15-1/vite.config.ts
@@ -11,4 +11,14 @@ export default defineConfig({
     },
     global: {},
   },
+  server: {
+    proxy: {
+      "/api/blueapi": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/api\/blueapi/, ""),
+      },
+    },
+  },
 });


### PR DESCRIPTION
Fixes #85 

To test:
* Run up a local BlueAPI e.g. as in https://github.com/DiamondLightSource/daq-queuing-service#daq_queuing_service
* Run the GUI as specified in the README for local mode
* Run a plan via the GUI
* Confirm the local blueapi gets called (e.g. look at the logs)